### PR TITLE
Change pep8 line length to 160

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length=160


### PR DESCRIPTION
Change the max length for pep8 checks from 80 characters per line to 160