### PR TITLE
Seting Key identifiers for RAS encrypter

### DIFF
--- a/swagger_server/controllers/submitter/encrypter.py
+++ b/swagger_server/controllers/submitter/encrypter.py
@@ -12,7 +12,6 @@ from swagger_server.controllers.cryptography.jwe_encryption import JWEEncrypter
 from swagger_server.controllers.helper import to_bytes, to_str
 from swagger_server.controllers.cryptography.keys import TEST_PRIVATE_SIGNING_KEY, TEST_PRIVATE_SIGNING_KEY_PASSWORD, \
     TEST_SDX_PUBLIC_KEY
-KID = 'EDCSR'
 
 
 class Encrypter(JWEEncrypter):
@@ -41,7 +40,7 @@ class Encrypter(JWEEncrypter):
         self.public_key = serialization.load_pem_public_key(data=public_key_bytes, backend=backend)
 
     def _jwe_protected_header(self):
-        return self._base_64_encode(b'{"alg":"RSA-OAEP","enc":"A256GCM"}')
+        return self._base_64_encode(b'{"alg":"RSA-OAEP","enc":"A256GCM","kid":"inbound-encryption}')
 
     def _encrypted_key(self, cek):
         ciphertext = self.public_key.encrypt(cek, padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA1()), algorithm=hashes.SHA1(), label=None))
@@ -51,7 +50,7 @@ class Encrypter(JWEEncrypter):
         return self._base_64_encode(iv)
 
     def _encode_and_signed(self, payload):
-        return jwt.encode(payload, self.private_key, algorithm="RS256", headers={'kid': KID, 'typ': 'jwt'})
+        return jwt.encode(payload, self.private_key, algorithm="RS256", headers={'kid': "inbound-signing", 'typ': 'jwt'})
 
     def encrypt(self, json):
         payload = self._encode_and_signed(json)


### PR DESCRIPTION
These need to be set now as SDX is using the new crypto lib which assumes the KIDs are present in both the JWT and JWE headers