### PR TITLE
Fix out of memory error during file upload

### DIFF
--- a/swagger_server/controllers/collectioninstrument.py
+++ b/swagger_server/controllers/collectioninstrument.py
@@ -322,7 +322,7 @@ class CollectionInstrument(object):
                         raise Exception('no survey ID returned')
                     survey = SurveyModel(survey_id=survey_id)
                     ons_env.db.session.add(survey)
-                survey.instruments.append(instrument)
+                instrument.survey_id = survey.id
         except Exception as e:
             ons_env.logger.error('Error uploading file: {}'.format(str(e)))
             return 500, 'error uploading file'

--- a/swagger_server/controllers/collectioninstrument.py
+++ b/swagger_server/controllers/collectioninstrument.py
@@ -309,7 +309,6 @@ class CollectionInstrument(object):
                 instrument.exercises.append(exercise)
                 instrument.businesses.append(business)
                 instrument.classifications.append(classifier)
-                ons_env.db.session.add(instrument)
                 survey = self._get_survey(survey_id)
                 if not survey:
                     if reactor.running:
@@ -322,7 +321,8 @@ class CollectionInstrument(object):
                         raise Exception('no survey ID returned')
                     survey = SurveyModel(survey_id=survey_id)
                     ons_env.db.session.add(survey)
-                instrument.survey_id = survey.id
+                instrument.survey = survey
+                ons_env.db.session.add(instrument)
         except Exception as e:
             ons_env.logger.error('Error uploading file: {}'.format(str(e)))
             return 500, 'error uploading file'


### PR DESCRIPTION
Set the survey id on instrument rather than appending instrument  to the list on survey, as that causes the whole instrument table to be loaded into memory which in turns crashes the application as the table contains large binary blobs.