### PR TITLE
Remove Python-magic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,5 +62,3 @@ pika==0.10.0
 jsonpickle==0.8.0
 flake8-mock==0.3
 Flask-HTTPAuth==3.2.3
-python-magic==0.4.13
-libmagic==1.0

--- a/swagger_server/controllers/survey_response.py
+++ b/swagger_server/controllers/survey_response.py
@@ -2,7 +2,6 @@ import os
 import requests
 import time
 import uuid
-import magic
 
 from ons_ras_common import ons_env
 from swagger_server.controllers.helper import is_valid_file_extension, is_valid_file_name_length, \
@@ -18,7 +17,6 @@ UPLOAD_SUCCESSFUL = 'Upload successful'
 UPLOAD_UNSUCCESSFUL = 'Upload failed'
 INVALID_UPLOAD = 'The upload must have valid case_id and a file attached'
 QUEUE_NAME = 'Seft.Responses'
-MICROSOFT_DOCUMENT_FORMAT ="Composite Document File V2 Document"
 
 
 class SurveyResponse(object):
@@ -38,8 +36,7 @@ class SurveyResponse(object):
 
         if case_id and file and hasattr(file, 'filename'):
             file_name, file_extension = os.path.splitext(secure_filename(file.filename))
-            file_contents = file.read()
-            is_valid_file, msg = self._is_valid_file(file_contents, file_name, file_extension)
+            is_valid_file, msg = self._is_valid_file(file_name, file_extension)
 
             if not is_valid_file:
                 return 400, msg
@@ -65,6 +62,7 @@ class SurveyResponse(object):
 
             # Create, encrypt and send message to rabbitmq
             generated_file_name = self._generate_file_name(ru, exercise_ref, survey_id, file_extension)
+            file_contents = file.read()
             json_message = self._create_json_message_for_file(generated_file_name, file_contents, case_id)
             encrypted_message = self._encrypt_message(json_message)
 
@@ -173,7 +171,7 @@ class SurveyResponse(object):
         return 400, INVALID_UPLOAD
 
     @staticmethod
-    def _is_valid_file(file_contents, file_name, file_extension):
+    def _is_valid_file(file_name, file_extension):
         """
         Check a file is valid
         :param file_contents: The file contents
@@ -187,12 +185,6 @@ class SurveyResponse(object):
         if not is_valid_file_extension(file_extension, ons_env.get('upload_file_extensions')):
             ons_env.logger.info('File extension not valid')
             return False, FILE_EXTENSION_ERROR
-
-        file_type = magic.from_buffer(file_contents)
-
-        if MICROSOFT_DOCUMENT_FORMAT not in file_type:
-            ons_env.logger.error('The file extension has been altered, the original file is {}'.format(file_type))
-            raise UploadException()
 
         if not is_valid_file_name_length(file_name, ons_env.get('max_upload_file_name_length')):
             ons_env.logger.info('File name too long')

--- a/swagger_server/test/test_survey_response.py
+++ b/swagger_server/test/test_survey_response.py
@@ -17,7 +17,6 @@ from unittest.mock import patch, Mock
 from unittest.mock import MagicMock
 
 TEST_FILE_LOCATION = 'swagger_server/test/test.xlsx'
-TEST_FILE_CHANGED_EXTENSION_LOCATION = 'swagger_server/test/fake_exe.xls'
 
 
 class TestSurveyResponse(unittest.TestCase):
@@ -168,17 +167,6 @@ class TestSurveyResponse(unittest.TestCase):
         # Then the file fails to upload, returning 400 and file name length error
         self.assertEquals(status, 400)
         self.assertEquals(FILE_NAME_LENGTH_ERROR, msg)
-
-    def test_add_survey_response_file_extension_changed(self):
-        # Given a survey response which has been changed from a exe to a xls
-        with open(TEST_FILE_CHANGED_EXTENSION_LOCATION, 'rb') as io:
-            file = FileStorage(stream=io, filename='test.xls')
-
-            # When the file is posted to the end point with a case_id
-            case_id = 'ab548d78-c2f1-400f-9899-79d944b87300'
-            # Then a upload exception is raised
-            with self.assertRaises(UploadException):
-                self.survey_response.add_survey_response(case_id, file)
 
 
     def test_add_survey_response_file_extension(self):


### PR DESCRIPTION
**THIS PR NEEDS FURTHER DISCUSSION BEFORE BEING MERGED. THIS IS A POTENTIAL OPTION IF NEEDED**

Python magic is not working as expected, some files are being identified as being Zip archive data when they are of type xls. This will stop uploading of file. This PR remove the python-magic code

