### PR TITLE
moves jwt keys out of the [default] group. this means that when the s…

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -72,9 +72,6 @@ authentication = false
 ;   Encryption settings, for production purposes all these settings need to be
 ;   provided via environment variables.
 ;
-crypto_key = ONS_DUMMY_KEY
-jwt_algorithm = HS256
-jwt_secret = vrwgLNWEffe45thh545yuby
 security_user_name = dummy_user
 security_user_password = dummy_password
 security_realm = sdc
@@ -108,11 +105,19 @@ drop_database = yes
 db_connection = sqlite:///${db_name}
 debug = false
 log_level = INFO
+crypto_key = ONS_DUMMY_KEY
+jwt_algorithm = HS256
+jwt_secret = foobar
+
 
 [development]
 authentication = false
 db_schema = ras_ci
 db_connection = ${db_driver}://${db_user}:${db_pass}@${db_host}:${db_port}/${db_name}
+crypto_key = ONS_DUMMY_KEY
+jwt_algorithm = HS256
+jwt_secret = foobar
+
 
 [test]
 api_protocol = https
@@ -122,6 +127,10 @@ authentication = false
 protocol = https
 db_service = ras-postgres
 db_schema = ras_ci
+crypto_key = ONS_DUMMY_KEY
+jwt_algorithm = HS256jwt
+jwt_secret = foobar
+
 
 [demo]
 api_protocol = https


### PR DESCRIPTION
Nothing special, just making sure our jwt keys are not available in the default section. Hence the system fails if you don't set them via an environment variable - or run ONS_ENV=travis or ONS_ENV=dev 