### PR TITLE
Return instrument size as string without \n

### DIFF
--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -75,6 +75,6 @@ def instrument_size(instrument_id):
     instrument = CollectionInstrument().get_instrument_json(instrument_id)
 
     if instrument and 'len' in instrument:
-        return make_response(jsonify(instrument['len']), 200)
+        return make_response(str(instrument['len']), 200)
 
     return make_response(COLLECTION_INSTRUMENT_NOT_FOUND, 404)


### PR DESCRIPTION
Small fix to stop collection instrument size endpoint returning `\n` at the end of responses.

We were jsonifying the string when we didn't need to