### PR TITLE
Add info details to view

### DIFF
--- a/application/views/info_view.py
+++ b/application/views/info_view.py
@@ -1,12 +1,24 @@
+import json
+import os
+
 from flask import Blueprint, make_response, current_app, jsonify
+
 
 info_view = Blueprint('info_view', __name__)
 
 
 @info_view.route('/info', methods=['GET'])
 def get_info():
-    return make_response(
-        jsonify({
+
+    git_info = {}
+    if os.path.exists('git_info'):
+        with open('git_info') as io:
+            git_info = json.loads(io.read())
+
+    app_info = {
             "name": current_app.config['NAME'],
             "version": current_app.config['VERSION'],
-        }), 200)
+           }
+    info = dict(git_info, **app_info)
+
+    return make_response(jsonify(info), 200)

--- a/tests/views/test_info_view.py
+++ b/tests/views/test_info_view.py
@@ -1,4 +1,5 @@
 from tests.test_client import TestClient
+from unittest.mock import patch, mock_open
 
 
 class TestInfoView(TestClient):
@@ -6,10 +7,13 @@ class TestInfoView(TestClient):
 
     def test_info(self):
 
-        # Given the application is running
-        # When a get is made to the info end point
-        response = self.client.get('/info')
+        # Given the application is running and the git path is mocked
+        with patch('os.path.exists', return_value=True),\
+             patch("builtins.open", mock_open(read_data='{\"origin\": \"test\"}')):
+                # When a call to the info end point is made
+                response = self.client.get('/info')
 
-        # Then the info returns a 200
-        self.assertStatus(response, 200)
-        self.assertIn('ras-collection-instrument', response.data.decode())
+                # Then it returns details from git and the app
+                self.assertIn('origin', response.data.decode())
+                self.assertIn('name', response.data.decode())
+                self.assertIn('version', response.data.decode())


### PR DESCRIPTION
Request from Tech lead to add details to the info end point to align with other services. Currently deployed to http://ras-collection-instrument-dev.apps.devtest.onsclofo.uk/info if a visual check is need.