### PR TITLE
Use pycryptodome instead of pycryto

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,7 +20,6 @@ gunicorn = "==19.7.1"
 sqlalchemy-utils = "==0.32.14"
 sqlalchemy = "==1.1.10"
 "psycopg2" = "==2.7.1"
-pycrypto = "==2.6.1"
 structlog = "==17.2.0"
 werkzeug = "==0.12.2"
 sdc-cryptography = "==0.2.0"
@@ -33,6 +32,7 @@ xlsxwriter = "==1.0.2"
 retrying = "==1.3.3"
 sdc-rabbit = "==1.2.1"
 alembic = "==0.9.6"
+pycryptodome = "==3.4.6"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,18 +1,18 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b9d381c96920658c5f9e01150dc81a8d6ad3916d2fc945a990db82c4fa57bb5b"
+            "sha256": "d381fecf08b2921bf435f3ab9abd8b688186aca4f71d67304a7a6d8319ecfbe9"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.1",
+            "implementation_version": "3.6.3",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
+            "platform_release": "17.3.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
-            "python_full_version": "3.6.1",
+            "platform_version": "Darwin Kernel Version 17.3.0: Thu Nov  9 18:09:22 PST 2017; root:xnu-4570.31.3~1/RELEASE_X86_64",
+            "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "darwin"
         },
@@ -44,10 +44,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "cfenv": {
             "hashes": [
@@ -254,11 +254,21 @@
             ],
             "version": "==2.18"
         },
-        "pycrypto": {
+        "pycryptodome": {
             "hashes": [
-                "sha256:f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
+                "sha256:dfb3bf662c039cb4bae9fb1e8dcac57bc42db0a655375ad6e61f87ecc1c52b8a",
+                "sha256:f9da6fa2364e261b5fb1cace99d1311990ac7c278a5227cd2e0ea46015f9ecd1",
+                "sha256:1f76f89292c2825182c7b89b0ea8b6937b0c712a59e4f1502d438df2802077cc",
+                "sha256:966cabf5da7d1943a52d37df84f2885a2699b5bfe1203d9f12ba871aa965eabc",
+                "sha256:78f67dee479cdebd87745bf9399f2a2b883eb43e09a54a5ca3889c445b3b975a",
+                "sha256:3942292ba9576e9609e3d68b82f16de8f1ab31346df9b9f146c32e23dd17e234",
+                "sha256:03ed76c10948f8aff074fbeda8d49926ed58bdf45a0a99536d2c62caf21559f3",
+                "sha256:07a5c3a0112681eaed56c179ab55dba1998c13a83a3eb3bbb715b4dafd181151",
+                "sha256:bbec659a7997bfbc8a8dfbdb669edd31ec68f5c4bdd3b75744fe89b1285f46e0",
+                "sha256:e225c388855b2b6b21ca9af7e995eb93fb560c6aeefc132181227515224433d4",
+                "sha256:df1be662060cf3abdcf2086ebb401f750744106425ddebf74c57feab410e4923"
             ],
-            "version": "==2.6.1"
+            "version": "==3.4.6"
         },
         "python-dateutil": {
             "hashes": [


### PR DESCRIPTION
`pipenv check` spots a vulnerability defined here
https://www.cvedetails.com/cve/CVE-2013-7459/. A stackoverflow post
suggests pycryptodome is a drop in replacement for pycrypto
https://stackoverflow.com/questions/41813030/problems-with-installation-pycrypto-in-python-3-6