### PR TITLE
Make the survey id from the search return as a array

### DIFF
--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -54,7 +54,7 @@ class CollectionInstrument(object):
                 'id': instrument.instrument_id,
                 'file_name': instrument.file_name,
                 'classifiers': {**classifiers, **ru, **collection_exercise},
-                'surveyId': instrument.survey.survey_id
+                'surveyId': [instrument.survey.survey_id]
             }
             result.append(instrument_json)
         return result


### PR DESCRIPTION
This is a temporary fix for bricks and blocks. Although survey_id shouldn't be an array, this has been done to allow another service to work. A TBL will be raised to fix the other service properly