### PR TITLE
TBL 127 Remove the Ru reference on download

### DIFF
--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -168,10 +168,10 @@ class CollectionInstrument(object):
         log.info('Getting csv for instruments', exercise_id=exercise_id)
 
         validate_uuid(exercise_id)
-        csv_format = '"{count}","{ru_ref}","{length}","{date_stamp}"\n'
+        csv_format = '"{count}","{file_name}","{length}","{date_stamp}"\n'
         count = 1
         csv = csv_format.format(count='Count',
-                                ru_ref='RU Code',
+                                file_name='File Name',
                                 length='Length',
                                 date_stamp='Time Stamp')
         exercise = query_exercise_by_id(exercise_id, session)
@@ -180,12 +180,11 @@ class CollectionInstrument(object):
             return None
 
         for instrument in exercise.instruments:
-            for business in instrument.businesses:
-                csv += csv_format.format(count=count,
-                                         ru_ref=business.ru_ref,
-                                         length=instrument.len,
-                                         date_stamp=instrument.stamp)
-                count += 1
+            csv += csv_format.format(count=count,
+                                     file_name=instrument.file_name,
+                                     length=instrument.len,
+                                     date_stamp=instrument.stamp)
+            count += 1
         return csv
 
     @staticmethod
@@ -207,19 +206,19 @@ class CollectionInstrument(object):
         """
         Get the instrument data from the db using the id
         :param instrument_id: The id of the instrument we want
-        :return: data and ru_ref
+        :return: data and file_name
         """
 
         instrument = CollectionInstrument.get_instrument_by_id(instrument_id, session)
 
         data = None
-        ru_ref = None
+        file_name = None
         if instrument:
             log.info('Decrypting collection instrument data', instrument_id=instrument_id)
             cryptographer = Cryptographer()
             data = cryptographer.decrypt(instrument.data)
-            ru_ref = instrument.businesses[0].ru_ref
-        return data, ru_ref
+            file_name = instrument.file_name
+        return data, file_name
 
     @staticmethod
     def get_instrument_by_id(instrument_id, session):

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -64,11 +64,11 @@ def collection_instrument_by_id(instrument_id):
 
 @collection_instrument_view.route('/download/<instrument_id>', methods=['GET'])
 def instrument_data(instrument_id):
-    data, ru_ref = CollectionInstrument().get_instrument_data(instrument_id)
+    data, file_name = CollectionInstrument().get_instrument_data(instrument_id)
 
-    if data and ru_ref:
+    if data and file_name:
         response = make_response(data, 200)
-        response.headers["Content-Disposition"] = "attachment; filename={}.xlsx".format(ru_ref)
+        response.headers["Content-Disposition"] = "attachment; filename={}.xlsx".format(file_name)
         response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     else:
         response = make_response(COLLECTION_INSTRUMENT_NOT_FOUND, 404)

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -68,7 +68,7 @@ def instrument_data(instrument_id):
 
     if data and file_name:
         response = make_response(data, 200)
-        response.headers["Content-Disposition"] = "attachment; filename={}.xlsx".format(file_name)
+        response.headers["Content-Disposition"] = "attachment; filename={}".format(file_name)
         response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     else:
         response = make_response(COLLECTION_INSTRUMENT_NOT_FOUND, 404)

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -77,8 +77,8 @@ class TestCollectionInstrumentView(TestClient):
 
             # Then the response contains the correct data
             self.assertStatus(response, 200)
-            self.assertIn('"Count","RU Code","Length","Time Stamp"', response.data.decode())
-            self.assertIn('"1","test_ru_ref","999"', response.data.decode())
+            self.assertIn('"Count","File Name","Length","Time Stamp"', response.data.decode())
+            self.assertIn('"1","file_name","999"', response.data.decode())
 
     def test_get_instrument_by_search_string_ru(self):
 


### PR DESCRIPTION
Ru ref is being used for both the download instrument and download csv end points. Now we have moved to collection instruments without Ru ref we need to change this to file_name.
