### PR TITLE
Use stdout for logging

### DIFF
--- a/application/controllers/survey_response.py
+++ b/application/controllers/survey_response.py
@@ -6,7 +6,7 @@ import uuid
 
 from flask import current_app
 from sdc.rabbit.exceptions import PublishMessageError
-from sdc.rabbit.publisher import QueuePublisher
+from sdc.rabbit import QueuePublisher
 
 from application.controllers.helper import (is_valid_file_extension, is_valid_file_name_length,
                                             convert_file_object_to_string_base64)

--- a/application/logger_config.py
+++ b/application/logger_config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 
 from structlog import configure
 from structlog.processors import JSONRenderer, TimeStamper
@@ -31,7 +32,7 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
-    logging.basicConfig(level=log_level, format=logger_format)
+    logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
     configure(processors=[add_log_level, filter_by_level, add_service,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
                           JSONRenderer(indent=indent)])


### PR DESCRIPTION
Imports publisher from sdc rabbit app module rather than publisher file protects against name changes in the repo. Also use stdout for application logging rather than stderr.