### PR TITLE
US042 Add endpoint for returning count of collection instruments

### DIFF
--- a/API.md
+++ b/API.md
@@ -41,7 +41,7 @@ Example CSV Response
 
 ### Download a collection instrument
 
-* `GET /collection-instrument-api/1.0.2/download/adc8dcc1-c35f-4caf-8f5d-93e6287d4872`
+* `GET /collection-instrument-api/1.0.2/download/<instrument_id>`
 
 Example File Returned
 ```
@@ -50,11 +50,20 @@ adc8dcc1-c35f-4caf-8f5d-93e6287d4872.xlsx
 
 ### Get the size of a collection instrument
 
-* `GET /collection-instrument-api/1.0.2/instrument_size/adc8dcc1-c35f-4caf-8f5d-93e6287d4872`
+* `GET /collection-instrument-api/1.0.2/instrument_size/<instrument_id>`
 
 Example Response
 ```
 52224
+```
+
+### Get count of collection instruments
+
+* `GET /collection-instrument-api/1.0.2/collectioninstrument/count`
+
+Example Response
+```
+555
 ```
 
 ### Get count of collection instruments by search string

--- a/API.md
+++ b/API.md
@@ -57,6 +57,15 @@ Example Response
 52224
 ```
 
+### Get count of collection instruments by search string
+
+* `GET /collection-instrument-api/1.0.2/collectioninstrument/count?searchString={"COLLECTION_EXERCISE":%20"<exercise_id>"}`
+
+Example Response
+```
+123
+```
+
 ### Get collection instrument by search string
 
 * `GET /collection-instrument-api/1.0.2/collectioninstrument?searchString={"FORM_TYPE":%20"001"}`

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -53,6 +53,13 @@ def collection_instrument_by_search_string():
     return make_response(jsonify(instruments), 200)
 
 
+@collection_instrument_view.route('/collectioninstrument/count', methods=['GET'])
+def count_collection_instruments_by_search_string():
+    search_string = request.args.get('searchString')
+    instruments = CollectionInstrument().get_instrument_by_search_string(search_string)
+    return make_response(str(len(instruments)), 200)
+
+
 @collection_instrument_view.route('/collectioninstrument/id/<instrument_id>', methods=['GET'])
 def collection_instrument_by_id(instrument_id):
     instrument_json = CollectionInstrument().get_instrument_json(instrument_id)

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -193,6 +193,86 @@ class TestCollectionInstrumentView(TestClient):
         self.assertIn('test_ru_ref', response.data.decode())
         self.assertEqual(response.data.decode().count('cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'), 2)
 
+    def test_count_instrument_by_search_string_ru(self):
+
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with a search string
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count?searchString={"RU_REF":%20"test_ru_ref"}',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 1)
+
+    def test_single_count_instrument(self):
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with a search string
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 1)
+
+    def test_multiple_count_instrument(self):
+
+        # Given a second instrument in the db
+        self.add_instrument_data()
+        # When the collection instrument end point is called with a search string
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 2)
+
+    def test_count_instrument_by_search_classifier(self):
+
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with a search classifier
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count?searchString={"FORM_TYPE":%20"001"}',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 1)
+
+    def test_count_instrument_by_search_multiple_classifiers(self):
+
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with a multiple search classifiers
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count?'
+            'searchString={"FORM_TYPE":%20"001","GEOGRAPHY":%20"EN"}',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 1)
+
+    def test_count_instrument_by_search_multiple_bad_classifiers(self):
+
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with a multiple search classifiers
+        response = self.client.get(
+            '/collection-instrument-api/1.0.2/collectioninstrument/count?'
+            'searchString={"FORM_TYPE":%20"666","GEOGRAPHY":%20"GB"}',
+            headers=self.get_auth_headers())
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        json_data = json.loads(response.data)
+        self.assertEqual(json_data, 0)
+
     def test_get_instrument_by_id(self):
 
         # Given an instrument which is in the db


### PR DESCRIPTION
To decouple the collection exercise from the known number of associated CI's, it is necessary to add a `/count` endpoint to the collection instrument (this) service.