### PR TITLE
US042 Add retry for rabbitmq initialisation

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,10 @@ except RetryError:
     logger.exception('Failed to initialise database')
     exit(1)
 
-initialise_rabbit(app)
+try:
+    initialise_rabbit(app)
+except RetryError:
+    logger.exception('Failed to initialise rabbitmq')
+    exit(1)
 
 scheme, host, port = app.config['SCHEME'], app.config['HOST'], int(app.config['PORT'])

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -100,7 +100,7 @@ class CollectionInstrument(object):
     @staticmethod
     def initialise_messaging():
         log.info('Initialising rabbitmq exchange for Collection Instruments', queue=RABBIT_QUEUE_NAME)
-        return initialise_rabbitmq_exchange(RABBIT_QUEUE_NAME)
+        initialise_rabbitmq_exchange(RABBIT_QUEUE_NAME)
 
     @staticmethod
     def publish_uploaded_collection_instrument(exercise_id, instrument_id):

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -3,7 +3,6 @@ import logging
 import structlog
 
 from flask import current_app
-from pika.exceptions import AMQPConnectionError
 from sdc.rabbit.exceptions import PublishMessageError
 from sdc.rabbit import DurableExchangePublisher, QueuePublisher
 
@@ -35,14 +34,9 @@ def _initialise_rabbitmq(queue_name, publisher_type):
     rabbitmq_amqp = current_app.config['RABBITMQ_AMQP']
     log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
-    try:
-        # NB: _connect declares a queue or exchange
-        publisher._connect()
-        log.info('Successfully initialised rabbitmq', queue=queue_name)
-        return True
-    except AMQPConnectionError:
-        log.exception('Failed to initialise rabbitmq', queue=queue_name)
-        return False
+    # NB: _connect declares a queue or exchange
+    publisher._connect()
+    log.info('Successfully initialised rabbitmq', queue=queue_name)
 
 
 def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, encrypt=True):

--- a/tests/controllers/test_collection_instrument.py
+++ b/tests/controllers/test_collection_instrument.py
@@ -68,15 +68,12 @@ class TestCollectionInstrument(TestClient):
 
     def test_initialise_messaging(self):
         with patch('pika.BlockingConnection'):
-            result = self.collection_instrument.initialise_messaging()
-
-        self.assertTrue(result)
+            self.collection_instrument.initialise_messaging()
 
     def test_initialise_messaging_rabbit_fails(self):
-        with patch('pika.BlockingConnection', side_effect=AMQPConnectionError):
-            result = self.collection_instrument.initialise_messaging()
-
-        self.assertFalse(result)
+        with self.assertRaises(AMQPConnectionError):
+            with patch('pika.BlockingConnection', side_effect=AMQPConnectionError):
+                self.collection_instrument.initialise_messaging()
 
     def test_publish_uploaded_collection_instrument(self):
 

--- a/tests/controllers/test_survey_response.py
+++ b/tests/controllers/test_survey_response.py
@@ -25,15 +25,12 @@ class TestSurveyResponse(TestClient):
 
     def test_initialise_messaging(self):
         with patch('pika.BlockingConnection'):
-            result = self.survey_response.initialise_messaging()
-
-        self.assertTrue(result)
+            self.survey_response.initialise_messaging()
 
     def test_initialise_messaging_rabbit_fails(self):
-        with patch('pika.BlockingConnection', side_effect=AMQPConnectionError):
-            result = self.survey_response.initialise_messaging()
-
-        self.assertFalse(result)
+        with self.assertRaises(AMQPConnectionError):
+            with patch('pika.BlockingConnection', side_effect=AMQPConnectionError):
+                self.survey_response.initialise_messaging()
 
     def test_add_survey_response_success(self):
 


### PR DESCRIPTION
The rabbitmq instance may not yet be ready to accept connections when the collection instrument service is started. This retries the initialisation steps (and therefore the connection to the provided rabbitmq URL) repeatedly until it fails (similar to init for the database).