### PR TITLE
Use multiple rabbit instances

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,13 +20,15 @@ pipeline {
                 CF_DOMAIN = credentials('CF_DOMAIN')
                 DEV_SECURITY = credentials('DEV_SECURITY')
                 CF_USER = credentials('CF_USER')
-                RABBITMQ_AMQP = credentials('RABBITMQ_AMQP')
+                RABBITMQ_AMQP_SURVEY_RESPONSE = credentials('RABBITMQ_AMQP_SURVEY_RESPONSE')
+                RABBITMQ_AMQP_COLLECTION_INSTRUMENT = credentials('RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s dev"
                 sh 'cf push --no-start ras-collection-instrument-dev'
                 sh 'cf set-env ras-collection-instrument-dev ONS_ENV dev'
-                sh "cf set-env ras-collection-instrument-dev RABBITMQ_AMQP ${env.RABBITMQ_AMQP}"
+                sh "cf set-env ras-collection-instrument-dev RABBITMQ_AMQP_SURVEY_RESPONSE ${env.RABBITMQ_AMQP_SURVEY_RESPONSE}"
+                sh "cf set-env ras-collection-instrument-dev RABBITMQ_AMQP_COLLECTION_INSTRUMENT ${env.RABBITMQ_AMQP_COLLECTION_INSTRUMENT}"
                 sh "cf set-env ras-collection-instrument-dev SECURITY_USER_NAME ${env.DEV_SECURITY_USR}"
                 sh "cf set-env ras-collection-instrument-dev SECURITY_USER_PASSWORD ${env.DEV_SECURITY_PSW}"
 
@@ -76,13 +78,15 @@ pipeline {
                 CF_DOMAIN = credentials('CF_DOMAIN')
                 CI_SECURITY = credentials('CI_SECURITY')
                 CF_USER = credentials('CF_USER')
-                RABBITMQ_AMQP = credentials('RABBITMQ_AMQP')
+                RABBITMQ_AMQP_SURVEY_RESPONSE = credentials('RABBITMQ_AMQP_SURVEY_RESPONSE')
+                RABBITMQ_AMQP_COLLECTION_INSTRUMENT = credentials('RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s ci"
                 sh 'cf push --no-start ras-collection-instrument-ci'
                 sh 'cf set-env ras-collection-instrument-ci ONS_ENV ci'
-                sh "cf set-env ras-collection-instrument-ci RABBITMQ_AMQP ${env.RABBITMQ_AMQP}"
+                sh "cf set-env ras-collection-instrument-ci RABBITMQ_AMQP_SURVEY_RESPONSE ${env.RABBITMQ_AMQP_SURVEY_RESPONSE}"
+                sh "cf set-env ras-collection-instrument-ci RABBITMQ_AMQP_COLLECTION_INSTRUMENT ${env.RABBITMQ_AMQP_COLLECTION_INSTRUMENT}"
                 sh "cf set-env ras-collection-instrument-ci SECURITY_USER_NAME ${env.CI_SECURITY_USR}"
                 sh "cf set-env ras-collection-instrument-ci SECURITY_USER_PASSWORD ${env.CI_SECURITY_PSW}"
 
@@ -155,13 +159,15 @@ pipeline {
                 CF_DOMAIN = credentials('CF_DOMAIN')
                 TEST_SECURITY = credentials('TEST_SECURITY')
                 CF_USER = credentials('CF_USER')
-                RABBITMQ_AMQP = credentials('RABBITMQ_AMQP')
+                RABBITMQ_AMQP_SURVEY_RESPONSE = credentials('RABBITMQ_AMQP_SURVEY_RESPONSE')
+                RABBITMQ_AMQP_COLLECTION_INSTRUMENT = credentials('RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
             }
             steps {
                 sh "cf login -a https://${env.CLOUDFOUNDRY_API} --skip-ssl-validation -u ${CF_USER_USR} -p ${CF_USER_PSW} -o rmras -s test"
                 sh 'cf push --no-start ras-collection-instrument-test'
                 sh 'cf set-env ras-collection-instrument-test ONS_ENV test'
-                sh "cf set-env ras-collection-instrument-test RABBITMQ_AMQP ${env.RABBITMQ_AMQP}"
+                sh "cf set-env ras-collection-instrument-test RABBITMQ_AMQP_SURVEY_RESPONSE ${env.RABBITMQ_AMQP_SURVEY_RESPONSE}"
+                sh "cf set-env ras-collection-instrument-test RABBITMQ_AMQP_COLLECTION_INSTRUMENT ${env.RABBITMQ_AMQP_COLLECTION_INSTRUMENT}"
                 sh "cf set-env ras-collection-instrument-test SECURITY_USER_NAME ${env.TEST_SECURITY_USR}"
                 sh "cf set-env ras-collection-instrument-test SECURITY_USER_PASSWORD ${env.TEST_SECURITY_PSW}"
 

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -24,14 +24,15 @@ def _encrypt_message(message_json):
     return encrypter.encrypt(message_json)
 
 
-def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp):
+def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp_config):
     """
     Initialise a rabbit queue or exchange is created ahead of use
     :param queue_name: The rabbit queue or exchange to initialise
     :param publisher_type: Publisher class from sdc-rabbit to use
-    :param rabbitmq_amqp: connection string for rabbitmq
+    :param rabbitmq_amqp_config: rabbitmq config item to refer to
     :return: boolean
     """
+    rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
     log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
@@ -39,7 +40,7 @@ def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp):
     log.info('Successfully initialised rabbitmq', queue=queue_name)
 
 
-def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbitmq_amqp, encrypt=True):
+def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbitmq_amqp_config, encrypt=True):
     """
     Send message to rabbitmq
     :param message: The message to send to the queue in JSON format
@@ -47,9 +48,10 @@ def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbit
     :param queue_name: The rabbit queue or exchange to publish to
     :param encrypt: Flag whether message should be encrypted before publication
     :param publisher_type: Publisher class from sdc-rabbit to use
-    :param rabbitmq_amqp: connection string for rabbitmq
+    :param rabbitmq_amqp_config: rabbitmq config item to refer to
     :return: boolean
     """
+    rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
     log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     message = _encrypt_message(message) if encrypt else message
@@ -62,7 +64,7 @@ def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbit
         return False
 
 
-initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_SURVEY_RESPONSE'])
-initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_COLLECTION_INSTRUMENT'])
-send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_SURVEY_RESPONSE'])
-send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_COLLECTION_INSTRUMENT']) # NOQA
+initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_SURVEY_RESPONSE')
+initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
+send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_SURVEY_RESPONSE')
+send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_COLLECTION_INSTRUMENT') # NOQA

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -33,7 +33,7 @@ def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp_config):
     :return: boolean
     """
     rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
-    log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
+    log.info('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
     publisher._connect()

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -24,14 +24,14 @@ def _encrypt_message(message_json):
     return encrypter.encrypt(message_json)
 
 
-def _initialise_rabbitmq(queue_name, publisher_type):
+def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp):
     """
     Initialise a rabbit queue or exchange is created ahead of use
     :param queue_name: The rabbit queue or exchange to initialise
     :param publisher_type: Publisher class from sdc-rabbit to use
+    :param rabbitmq_amqp: connection string for rabbitmq
     :return: boolean
     """
-    rabbitmq_amqp = current_app.config['RABBITMQ_AMQP']
     log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
@@ -39,7 +39,7 @@ def _initialise_rabbitmq(queue_name, publisher_type):
     log.info('Successfully initialised rabbitmq', queue=queue_name)
 
 
-def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, encrypt=True):
+def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbitmq_amqp, encrypt=True):
     """
     Send message to rabbitmq
     :param message: The message to send to the queue in JSON format
@@ -47,9 +47,9 @@ def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, encryp
     :param queue_name: The rabbit queue or exchange to publish to
     :param encrypt: Flag whether message should be encrypted before publication
     :param publisher_type: Publisher class from sdc-rabbit to use
+    :param rabbitmq_amqp: connection string for rabbitmq
     :return: boolean
     """
-    rabbitmq_amqp = current_app.config['RABBITMQ_AMQP']
     log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     message = _encrypt_message(message) if encrypt else message
@@ -62,7 +62,7 @@ def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, encryp
         return False
 
 
-initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher)
-initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher)
-send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher)
-send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq, publisher_type=DurableExchangePublisher) # NOQA
+initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_SURVEY_RESPONSE'])
+initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_COLLECTION_INSTRUMENT'])
+send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_SURVEY_RESPONSE'])
+send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp = current_app.config['RABBITMQ_AMQP_COLLECTION_INSTRUMENT']) # NOQA

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -33,7 +33,7 @@ def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp_config):
     :return: boolean
     """
     rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
-    log.debug ('Connecting to rabbitmq', url=rabbitmq_amqp)
+    log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
     publisher._connect()

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -33,7 +33,7 @@ def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp_config):
     :return: boolean
     """
     rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
-    log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
+    log.debug ('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
     publisher._connect()
@@ -64,7 +64,12 @@ def _send_message_to_rabbitmq(message, tx_id, queue_name, publisher_type, rabbit
         return False
 
 
-initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_SURVEY_RESPONSE')
-initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
-send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_SURVEY_RESPONSE')
-send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq, publisher_type=DurableExchangePublisher, rabbitmq_amqp_config = 'RABBITMQ_AMQP_COLLECTION_INSTRUMENT') # NOQA
+initialise_rabbitmq_queue = functools.partial(_initialise_rabbitmq, publisher_type=QueuePublisher,
+                                              rabbitmq_amqp_config='RABBITMQ_AMQP_SURVEY_RESPONSE')
+initialise_rabbitmq_exchange = functools.partial(_initialise_rabbitmq, publisher_type=DurableExchangePublisher,
+                                                 rabbitmq_amqp_config='RABBITMQ_AMQP_COLLECTION_INSTRUMENT')
+send_message_to_rabbitmq_queue = functools.partial(_send_message_to_rabbitmq, publisher_type=QueuePublisher,
+                                                   rabbitmq_amqp_config='RABBITMQ_AMQP_SURVEY_RESPONSE')
+send_message_to_rabbitmq_exchange = functools.partial(_send_message_to_rabbitmq,
+                                                      publisher_type=DurableExchangePublisher,
+                                                      rabbitmq_amqp_config='RABBITMQ_AMQP_COLLECTION_INSTRUMENT') # NOQA

--- a/application/controllers/rabbit_helper.py
+++ b/application/controllers/rabbit_helper.py
@@ -33,7 +33,7 @@ def _initialise_rabbitmq(queue_name, publisher_type, rabbitmq_amqp_config):
     :return: boolean
     """
     rabbitmq_amqp = current_app.config[rabbitmq_amqp_config]
-    log.info('Connecting to rabbitmq', url=rabbitmq_amqp)
+    log.debug('Connecting to rabbitmq', url=rabbitmq_amqp)
     publisher = publisher_type([rabbitmq_amqp], queue_name)
     # NB: _connect declares a queue or exchange
     publisher._connect()

--- a/config.py
+++ b/config.py
@@ -18,7 +18,8 @@ class Config(object):
     ONS_CRYPTOKEY = os.getenv('ONS_CRYPTOKEY')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'admin')
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'secret')
-    RABBITMQ_AMQP = os.getenv('RABBITMQ_AMQP', 'rabbit_amqp')
+    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INTRUMENT', 'rabbit_amqp')
+    RABBITMQ_AMQP_SURVEY_RESPONSE = os.getenv('RABBITMQ_AMQP_SURVEY_RESPONSE', 'rabbit_amqp')
     MAX_UPLOAD_FILE_NAME_LENGTH = os.getenv('MAX_UPLOAD_FILE_NAME_LENGTH', 50)
     COLLECTION_EXERCISE_SCHEMA = os.getenv('COLLECTION_EXERCISE_SCHEMA',
                                            'application/schemas/collection_instrument_schema.json')
@@ -67,7 +68,8 @@ class TestingConfig(Config):
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
     DATABASE_URI = os.getenv('TEST_DATABASE_URI', 'postgres://postgres:postgres@localhost:6432/postgres')
-    RABBITMQ_AMQP = os.getenv('RABBITMQ_AMQP', 'amqp://guest:guest@localhost:5672')
+    RABBITMQ_AMQP_COLLECTION_INTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INTRUMENT', 'amqp://guest:guest@localhost:5672')
+    RABBITMQ_AMQP_SURVEY_RESPONSE = os.getenv('RABBITMQ_AMQP_SURVEY_RESPONSE', 'amqp://guest:guest@localhost:5672')
     DATABASE_SCHEMA = 'ras_ci'
     ONS_CRYPTOKEY = 'somethingsecure'
     JSON_SECRET_KEYS = open("./tests/files/keys.json").read()

--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ class Config(object):
     ONS_CRYPTOKEY = os.getenv('ONS_CRYPTOKEY')
     SECURITY_USER_NAME = os.getenv('SECURITY_USER_NAME', 'admin')
     SECURITY_USER_PASSWORD = os.getenv('SECURITY_USER_PASSWORD', 'secret')
-    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INTRUMENT', 'rabbit_amqp')
+    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INSTRUMENT', 'rabbit_amqp')
     RABBITMQ_AMQP_SURVEY_RESPONSE = os.getenv('RABBITMQ_AMQP_SURVEY_RESPONSE', 'rabbit_amqp')
     MAX_UPLOAD_FILE_NAME_LENGTH = os.getenv('MAX_UPLOAD_FILE_NAME_LENGTH', 50)
     COLLECTION_EXERCISE_SCHEMA = os.getenv('COLLECTION_EXERCISE_SCHEMA',
@@ -68,7 +68,7 @@ class TestingConfig(Config):
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
     DATABASE_URI = os.getenv('TEST_DATABASE_URI', 'postgres://postgres:postgres@localhost:6432/postgres')
-    RABBITMQ_AMQP_COLLECTION_INTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INTRUMENT', 'amqp://guest:guest@localhost:5672')
+    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INSTRUMENT', 'amqp://guest:guest@localhost:5672')
     RABBITMQ_AMQP_SURVEY_RESPONSE = os.getenv('RABBITMQ_AMQP_SURVEY_RESPONSE', 'amqp://guest:guest@localhost:5672')
     DATABASE_SCHEMA = 'ras_ci'
     ONS_CRYPTOKEY = 'somethingsecure'

--- a/config.py
+++ b/config.py
@@ -68,7 +68,8 @@ class TestingConfig(Config):
     SECURITY_USER_NAME = 'admin'
     SECURITY_USER_PASSWORD = 'secret'
     DATABASE_URI = os.getenv('TEST_DATABASE_URI', 'postgres://postgres:postgres@localhost:6432/postgres')
-    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INSTRUMENT', 'amqp://guest:guest@localhost:5672')
+    RABBITMQ_AMQP_COLLECTION_INSTRUMENT = os.getenv('RABBITMQ_AMQP_COLLECTION_INSTRUMENT',
+                                                    'amqp://guest:guest@localhost:5672')
     RABBITMQ_AMQP_SURVEY_RESPONSE = os.getenv('RABBITMQ_AMQP_SURVEY_RESPONSE', 'amqp://guest:guest@localhost:5672')
     DATABASE_SCHEMA = 'ras_ci'
     ONS_CRYPTOKEY = 'somethingsecure'


### PR DESCRIPTION
Collection instrument needs to be able to get to 2 different rabbit instances, one for the response uploads and a different one for collection instruments upload