### PR TITLE
Update pluggy 0.6.0 hashes as they've been changed

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -509,7 +509,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+                "sha256:714306e9b9a7b24ee4c1e3ff6463d7f652cdd30f4693121b31572e2fe1fdaea3",
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
             "version": "==0.6.0"
         },


### PR DESCRIPTION
The hash of pluggy 0.6.0 has been incorrectly updated, causing a build failure with a fresh virtual environment. This PR updates the hash to match the remote ones. 

See https://github.com/pytest-dev/pluggy/issues/135
and
https://github.com/ONSdigital/ras-secure-message/pull/190