### PR TITLE
Performance improvement 650 concurrency

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b 0.0.0.0:$PORT --workers 4 app:app
+web: gunicorn -b 0.0.0.0:$PORT --workers 8 app:app

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ cf = ONSCloudFoundry()
 
 class Config(object):
     NAME = os.getenv('RAS-COLLECTION-INSTRUMENT', 'ras-collection-instrument')
-    VERSION = os.getenv('VERSION', '1.2.0')
+    VERSION = os.getenv('VERSION', '1.2.1')
     SCHEME = os.getenv('http')
     HOST = os.getenv('HOST', '0.0.0.0')
     PORT = os.getenv('PORT', 8002)


### PR DESCRIPTION
# Motivation and Context
Performance Improvement

# What has changed
- Changing Gunicorn `sync` workers from 4 to 8.
- Requires 512M instance on cloud foundry environments.
- Incrementing version for release.

# How to test?
Has been load tested in Prunes. Just check the deployment pipeline is green after the changes are merged to `master`.

# Links
NA

# Screenshots (if appropriate):
