### PR TITLE
Publish message after transaction

### DIFF
--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -7,7 +7,7 @@ from flask import Blueprint
 from flask import make_response, request, jsonify
 
 from application.controllers.basic_auth import auth
-from application.controllers.collection_instrument import CollectionInstrument, log, RABBIT_QUEUE_NAME
+from application.controllers.collection_instrument import CollectionInstrument, RABBIT_QUEUE_NAME
 from application.controllers.rabbit_helper import send_message_to_rabbitmq_exchange
 from application.exceptions import RasError
 

--- a/tests/controllers/test_collection_instrument.py
+++ b/tests/controllers/test_collection_instrument.py
@@ -5,6 +5,7 @@ from pika.exceptions import AMQPConnectionError
 from sdc.rabbit.exceptions import PublishMessageError
 
 from application.controllers.collection_instrument import CollectionInstrument
+from application.views.collection_instrument_view import publish_uploaded_collection_instrument
 from application.controllers.session_decorator import with_db_session
 from application.exceptions import RasDatabaseError
 from application.models.models import ExerciseModel, InstrumentModel, BusinessModel, SurveyModel, SEFTModel
@@ -90,7 +91,7 @@ class TestCollectionInstrument(TestClient):
         # When publishing to a rabbit exchange that a collection instrument has been uploaded
         c_id = 'db0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
         with patch('pika.BlockingConnection'):
-            result = self.collection_instrument.publish_uploaded_collection_instrument(c_id, self.instrument_id)
+            result = publish_uploaded_collection_instrument(c_id, self.instrument_id)
 
         # Then the message is successfully published
         self.assertTrue(result)
@@ -104,7 +105,7 @@ class TestCollectionInstrument(TestClient):
         rabbit.publish_message = Mock(side_effect=PublishMessageError)
 
         with patch('sdc.rabbit.DurableExchangePublisher', return_value=rabbit):
-            result = self.collection_instrument.publish_uploaded_collection_instrument(c_id, self.instrument_id)
+            result = publish_uploaded_collection_instrument(c_id, self.instrument_id)
 
         # Then the message is not successfully published
         self.assertFalse(result)


### PR DESCRIPTION
# Motivation and Context
We were seeing intermittent issues where collection exercises would
fail to be set into `ready for live` state. We observed in the logs that
collection instrument counts from the collection exercise service was 0
after collection instrument had said it have saved a collection
instrument. This was likely because collection exercise processed the
message before the data changes were committed to the database. This change publishes the message after the data has been saved. The
downside to this is that if a message failed to publish then the data
would not be rolled back. To manage this scenario we log at error level
with relevant information

The theory of the issue
1. Upload collection instrument (CI service) - https://github.com/ONSdigital/ras-collection-instrument/blob/master/application/views/collection_instrument_view.py#L33
2. Save collection instrument to the database (uncommitted) (CI service) - https://github.com/ONSdigital/ras-collection-instrument/blob/master/application/controllers/collection_instrument.py#L97
3. Post message to rabbit for collection exercise to pick up (CI service) - https://github.com/ONSdigital/ras-collection-instrument/blob/master/application/controllers/collection_instrument.py#L98
4. Collection exercise consumes message (Collex service) - https://github.com/ONSdigital/rm-collection-exercise-service/blob/dcd68bf63ed0fa2f492f856b45cbd9e16c0025a0/src/main/java/uk/gov/ons/ctp/response/collection/exercise/message/impl/CollectionInstrumentLoadedReceiver.java#L19
5. Collection exercise calls collection instrument to count the CIs (Collex service) - https://github.com/ONSdigital/rm-collection-exercise-service/blob/10d13f7332eb77b5ac5ec368478fad949e97e1e6/src/main/java/uk/gov/ons/ctp/response/collection/exercise/service/impl/CollectionExerciseServiceImpl.java#L685
6. Commit data to database (CI service) - https://github.com/ONSdigital/ras-collection-instrument/blob/master/application/controllers/collection_instrument.py#L102

# What has changed
Publish message only after committing data

# How to test?
Not sure. Been testing in CI
