### PR TITLE
ZipKin Tracing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,17 +1,12 @@
 [[source]]
-
 name = "pypi"
 verify_ssl = true
 url = "https://pypi.python.org/simple"
 
-
 [requires]
-
 python_version = "3.6"
 
-
 [packages]
-
 cfenv = "*"
 flask = "*"
 flask-cors = "*"
@@ -32,10 +27,10 @@ retrying = "*"
 sdc-rabbit = "*"
 alembic = "*"
 pycryptodome = "*"
-
+requestsdefaulter = {git = "https://github.com/ONSdigital/requestsdefaulter.git", editable = true}
+flask-zipkin = "*"
 
 [dev-packages]
-
 coverage = "*"
 "flake8" = "*"
 "flake8-mock" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,7 @@ retrying = "*"
 sdc-rabbit = "*"
 alembic = "*"
 pycryptodome = "*"
-requestsdefaulter = {git = "https://github.com/ONSdigital/requestsdefaulter.git", editable = true}
+requestsdefaulter = "*"
 flask-zipkin = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8d63154d17ff3225ad4afa89a6e9f6cfdbc62e4b6f6e7a9252aad84348c14faa"
+            "sha256": "4279832af0995a6406b9e454b1786ff6ec2d0afce46f93dee80e9cb4f844b53f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -156,9 +156,9 @@
         },
         "furl": {
             "hashes": [
-                "sha256:5436226c89536b5fa8c5faa1e34d684d417f69dea91d406edaab102c5da6de8c"
+                "sha256:17654103b8d0cbe42798592db099c728165ac12057d49fe2e69de967d87bf29b"
             ],
-            "version": "==1.2"
+            "version": "==1.2.1"
         },
         "gevent": {
             "hashes": [
@@ -403,8 +403,12 @@
             "version": "==2.19.1"
         },
         "requestsdefaulter": {
-            "editable": true,
-            "git": "https://github.com/ONSdigital/requestsdefaulter.git"
+            "hashes": [
+                "sha256:5e185d9b38f29215c78446188afd70765a8e876244eec6a5f0e71ae437fdb128",
+                "sha256:bb83e7f96009be470d1dea55c270c9dad06fb231dd33dda483ab3d8ffb6b8102"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
         },
         "retrying": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b19580a42427aa637ca453101b14c35cad557b7908dff363cfa9b1214225ce3a"
+            "sha256": "8d63154d17ff3225ad4afa89a6e9f6cfdbc62e4b6f6e7a9252aad84348c14faa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -146,6 +146,14 @@
             "index": "pypi",
             "version": "==3.2.4"
         },
+        "flask-zipkin": {
+            "hashes": [
+                "sha256:402bed9a98d3507d82db98a8f7437fb52ef3684af33c58a241b37779f9013d74",
+                "sha256:fbd3e3c41ceeda922701eebbfce88c8fccb7bc849289d772f5186a14a49827bd"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
         "furl": {
             "hashes": [
                 "sha256:5436226c89536b5fa8c5faa1e34d684d417f69dea91d406edaab102c5da6de8c"
@@ -203,7 +211,7 @@
                 "sha256:fe3001b6a4f3f3582a865b9e5081cc548b973ec20320f297f5e2d46860e9c703",
                 "sha256:fe85bf7adb26eb47ad53a1bae5d35a28df16b2b93b89042a3a28746617a4738d"
             ],
-            "markers": "platform_python_implementation == 'CPython'",
+            "markers": "platform_python_implementation == 'cpython'",
             "version": "==0.4.14"
         },
         "gunicorn": {
@@ -266,6 +274,13 @@
             ],
             "version": "==0.11.2"
         },
+        "ply": {
+            "hashes": [
+                "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3",
+                "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+            ],
+            "version": "==3.11"
+        },
         "psycopg2": {
             "hashes": [
                 "sha256:0b9e48a1c1505699a64ac58815ca99104aacace8321e455072cee4f7fe7b2698",
@@ -301,6 +316,12 @@
             ],
             "index": "pypi",
             "version": "==2.7.5"
+        },
+        "py-zipkin": {
+            "hashes": [
+                "sha256:1cbf48c8b7e5a30c36e8eb97560b81813c38af0bdb6ad901b23bdbced15a9b79"
+            ],
+            "version": "==0.13.0"
         },
         "pycparser": {
             "hashes": [
@@ -381,6 +402,10 @@
             "index": "pypi",
             "version": "==2.19.1"
         },
+        "requestsdefaulter": {
+            "editable": true,
+            "git": "https://github.com/ONSdigital/requestsdefaulter.git"
+        },
         "retrying": {
             "hashes": [
                 "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
@@ -434,6 +459,12 @@
             "index": "pypi",
             "version": "==17.2.0"
         },
+        "thriftpy": {
+            "hashes": [
+                "sha256:309e57d97b5bfa01601393ad4f245451e989d6206a59279e56866b264a99796d"
+            ],
+            "version": "==0.3.9"
+        },
         "tornado": {
             "hashes": [
                 "sha256:0a6894559e62a186d6cc20f1c0e7318f83ae8e28922d75c4b6f83d42cc91d8b1",
@@ -449,7 +480,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version != '3.0.*' and python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*'",
             "version": "==1.23"
         },
         "werkzeug": {
@@ -495,8 +525,11 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
                 "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
@@ -519,11 +552,16 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
+                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
+                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
+                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
             ],
             "index": "pypi",
             "version": "==4.5.1"
@@ -597,7 +635,6 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -605,7 +642,6 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==1.5.4"
         },
         "pycodestyle": {
@@ -659,7 +695,6 @@
                 "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
                 "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.0.*'",
             "version": "==16.0.0"
         },
         "werkzeug": {

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 import os
+from distutils.util import strtobool
 
 from application.cloud.cloudfoundry import ONSCloudFoundry
 
@@ -35,6 +36,11 @@ class Config(object):
         DATABASE_SCHEMA = os.getenv('DATABASE_SCHEMA', 'ras_ci')
 
     UPLOAD_FILE_EXTENSIONS = 'xls,xlsx'
+
+    # Zipkin
+    ZIPKIN_DISABLE = bool(strtobool(os.getenv("ZIPKIN_DISABLE", "False")))
+    ZIPKIN_DSN = os.getenv("ZIPKIN_DSN", None)
+    ZIPKIN_SAMPLE_RATE = int(os.getenv("ZIPKIN_SAMPLE_RATE", 0))
 
     # dependencies
 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import structlog
+import requestsdefaulter
 
 from alembic.config import Config
 from alembic import command
@@ -13,6 +14,7 @@ from sqlalchemy import create_engine, column, text
 from sqlalchemy.exc import ProgrammingError, DatabaseError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.sql import exists, select
+from flask_zipkin import Zipkin
 
 from application.logger_config import logger_initial_config
 
@@ -22,8 +24,13 @@ logger = structlog.wrap_logger(logging.getLogger(__name__))
 def create_app(config=None):
     # create and configure the Flask application
     app = Flask(__name__)
+    app.name = "ras-collection-instrument"
     app_config = f"config.{config or os.environ.get('APP_SETTINGS', 'Config')}"
     app.config.from_object(app_config)
+
+    # Zipkin
+    zipkin = Zipkin(app=app, sample_rate=app.config.get("ZIPKIN_SAMPLE_RATE"))
+    requestsdefaulter.default_headers(zipkin.create_http_headers_for_new_span)
 
     # register view blueprints
     from application.views.survey_responses_view import survey_responses_view


### PR DESCRIPTION
Motivation and Context
==

Currently there's no way to trace the requests through the application.

What Changed
==

This will add the tracing headers to any request that comes through this
application onto another service, or preserve existing headers allowing
the user to follow requests through the application as a whole.

There are also new configuration settings:

```
| ZIPKIN_DISABLE                  | Totally disable Zipkin (including tracing headers)            | False
| ZIPKIN_DSN                      | Zipkin Sample API URL (e.g. http://zipkin:9411/api/v1/spans)  | None
| ZIPKIN_SAMPLE_RATE              | Percentage of requests to send to zipkin span API             | 0
```

By default this will add the tracing headers, but make no requests to
Zipkin's neat little UI.

How to test
==

No visible functional changes, check to see if downstream services are
receiving the headers:

* 'X-B3-TraceId'
* 'X-B3-SpanId'
* 'X-B3-ParentSpanId'
* 'X-B3-Flags'
* 'X-B3-Sampled'

You can also set the environment variables

To see the spans go to zipkin:

* Set the environment variable `ZIPKIN_DSN` to a locally running zipkin
  server
* Set the environment variable `ZIPKIN_SAMPLE_RATE` to 100

Then run the acceptance tests.

Links
==
* [Add Call time metrics into Splunk for Python Services (3d)][tkt]
* https://github.com/ONSdigital/ras-collection-instrument/pull/126
* https://github.com/ONSdigital/ras-party/pull/151
* https://github.com/ONSdigital/ras-secure-message/pull/227
* https://github.com/ONSdigital/response-operations-ui/pull/219
* https://github.com/ONSdigital/ras-frontstage/pull/383
* https://github.com/ONSdigital/rm-collection-exercise-service/pull/114
* https://github.com/ONSdigital/rm-case-service/pull/71
* https://github.com/ONSdigital/rm-actionexporter-service/pull/46
* https://github.com/ONSdigital/iac-service/pull/20
* https://github.com/ONSdigital/rm-sample-service/pull/74
* https://github.com/ONSdigital/rm-notify-gateway/pull/44
* https://github.com/ONSdigital/rm-sdx-gateway/pull/20
* https://github.com/ONSdigital/ras-party/pull/155
* https://github.com/ONSdigital/ras-rm-docker-dev/pull/80

[tkt]: https://trello.com/c/eY86bZG9/83-add-call-time-metrics-into-splunk-for-python-services-3d