### PR TITLE
Use smaller base layer for Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-slim
 WORKDIR /app
 COPY . /app
 EXPOSE 8002
-RUN apt-get update -y && apt-get install -y python-pip
+RUN apt-get update -y && apt-get install -y python-pip && apt-get install -y curl
 RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
 
 ENTRYPOINT ["python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.6
+FROM python:3.6-slim
 
 WORKDIR /app
 COPY . /app
 EXPOSE 8002
+RUN apt-get update -y && apt-get install -y python-pip
 RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
# Motivation and Context
Reduce size of Docker image from 1.07GB by using slimmer official version of base layer.
