### PR TITLE
Update dockerfile to use gunicorn to run app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,4 @@ EXPOSE 8002
 RUN apt-get update -y && apt-get install -y python-pip && apt-get install -y curl
 RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
 
-ENTRYPOINT ["python3"]
-CMD ["run.py"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec gunicorn app:app --bind 0.0.0.0:8002 --workers $GUNICORN_WORKERS --worker-class gevent --keep-alive 2 --timeout 30


### PR DESCRIPTION
# Motivation and Context
The current Dockerfile runs the app in the flask development server which is not production suitable. This changes the Dockerfile to use Gunicorn to run the app with a configurable number of workers.

# What has changed
- Use entrypoint script in dockerfile
- Make number of gunicorn workers configurable by environment variable

# How to test?
You can run this docker image locally with ras-rm-docker-dev or use the branch tag in docker hub to run it in the cloud. Note that I needed to increase the default rm-kubernetes memory limits to run more than 4 workers.

# Links
https://trello.com/c/1tmchm16/439-collection-instruments-need-to-run-in-gunicorn-in-docker