### PR TITLE
Execute the Collection Instrument service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM python:3.6-slim
 WORKDIR /app
 COPY . /app
 EXPOSE 8002
-RUN apt-get update -y && apt-get install -y python-pip && apt-get install -y curl
+RUN apt-get update -y && apt-get install -y python-pip
 RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
+
+RUN groupadd -g 992 collectioninstrumentsvc && \
+    useradd -r -u 992 -g collectioninstrumentsvc collectioninstrumentsvc
+USER collectioninstrumentsvc
 
 ENTRYPOINT ["python3"]
 CMD ["run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ EXPOSE 8002
 RUN apt-get update -y && apt-get install -y python-pip
 RUN pip3 install pipenv==8.3.1 && pipenv install --deploy --system
 
-RUN groupadd -g 992 collectioninstrumentsvc && \
-    useradd -r -u 992 -g collectioninstrumentsvc collectioninstrumentsvc
+RUN groupadd --gid 992 collectioninstrumentsvc && \
+    useradd --create-home --system --uid 992 --gid collectioninstrumentsvc collectioninstrumentsvc
 USER collectioninstrumentsvc
 
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

**IMPORTANT: Note that this change must be merged at the same time as [the pull request to update the Kubernetes manifests for this change](https://github.com/ONSdigital/census-rm-kubernetes/pull/29).**

# What has changed
The Dockerfile has been changed:

* cURL should not be installed as it increases the attack surface of the container
* Create a dedicated non-root user account for executing the Python code

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Python process running as the expected non-root user account

# Links
https://github.com/ONSdigital/census-rm-kubernetes/pull/29