### PR TITLE
updating env vars to be consistent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,8 +38,8 @@ pipeline {
                 sh "cf set-env ras-collection-instrument-dev COLLECTION_EXERCISE_HOST collectionexercisesvc-dev.${env.CF_DOMAIN}"
                 sh "cf set-env ras-collection-instrument-dev COLLECTION_EXERCISE_PORT 80"
 
-                sh "cf set-env ras-collection-instrument-dev RM_SURVEY_SERVICE_HOST surveysvc-dev.${env.CF_DOMAIN}"
-                sh "cf set-env ras-collection-instrument-dev RM_SURVEY_SERVICE_PORT 80"
+                sh "cf set-env ras-collection-instrument-dev SURVEY_SERVICE_HOST surveysvc-dev.${env.CF_DOMAIN}"
+                sh "cf set-env ras-collection-instrument-dev SURVEY_SERVICE_PORT 80"
                 sh 'cf start ras-collection-instrument-dev'
             }
         }
@@ -96,8 +96,8 @@ pipeline {
                 sh "cf set-env ras-collection-instrument-ci COLLECTION_EXERCISE_HOST collectionexercisesvc-ci.${env.CF_DOMAIN}"
                 sh "cf set-env ras-collection-instrument-ci COLLECTION_EXERCISE_PORT 80"
 
-                sh "cf set-env ras-collection-instrument-ci RM_SURVEY_SERVICE_HOST surveysvc-ci.${env.CF_DOMAIN}"
-                sh "cf set-env ras-collection-instrument-ci RM_SURVEY_SERVICE_PORT 80"
+                sh "cf set-env ras-collection-instrument-ci SURVEY_SERVICE_HOST surveysvc-ci.${env.CF_DOMAIN}"
+                sh "cf set-env ras-collection-instrument-ci SURVEY_SERVICE_PORT 80"
                 sh 'cf start ras-collection-instrument-ci'
             }
         }
@@ -177,8 +177,8 @@ pipeline {
                 sh "cf set-env ras-collection-instrument-test COLLECTION_EXERCISE_HOST collectionexertestsesvc-test.${env.CF_DOMAIN}"
                 sh "cf set-env ras-collection-instrument-test COLLECTION_EXERCISE_PORT 80"
 
-                sh "cf set-env ras-collection-instrument-test RM_SURVEY_SERVICE_HOST surveysvc-test.${env.CF_DOMAIN}"
-                sh "cf set-env ras-collection-instrument-test RM_SURVEY_SERVICE_PORT 80"
+                sh "cf set-env ras-collection-instrument-test SURVEY_SERVICE_HOST surveysvc-test.${env.CF_DOMAIN}"
+                sh "cf set-env ras-collection-instrument-test SURVEY_SERVICE_PORT 80"
                 sh 'cf start ras-collection-instrument-test'
             }
         }

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Environment variables available for configuration are listed below:
 | COLLECTION_EXERCISE_PROTOCOL | Protocol used for collection exercise service uri | 'http'
 | COLLECTION_EXERCISE_HOST     | Host address used for collection exercise uri | 'localhost'
 | COLLECTION_EXERCISE_PORT     | Port used for collection exercise uri | 8145
-| RM_SURVEY_SERVICE_PROTOCOL   | Protocol used for rm survey service uri | 'http'
-| RM_SURVEY_SERVICE_HOST       | Host address used for rm survey service uri | 'localhost'
-| RM_SURVEY_SERVICE_PORT       | Port used for rm survey service uri | 8080
+| SURVEY_SERVICE_PROTOCOL   | Protocol used for rm survey service uri | 'http'
+| SURVEY_SERVICE_HOST       | Host address used for rm survey service uri | 'localhost'
+| SURVEY_SERVICE_PORT       | Port used for rm survey service uri | 8080
 | PARTY_SERVICE_PROTOCOL       | Protocol used for party service uri | 'http'
 | PARTY_SERVICE_HOST           | Host address used for party service uri | 'localhost'
 | PARTY_SERVICE_PORT           | Port used for party service uri | 8081

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -98,7 +98,7 @@ def service_request(service, endpoint, search_value):
 
     try:
         service = {
-            'survey-service': current_app.config['RM_SURVEY_SERVICE'],
+            'survey-service': current_app.config['SURVEY_SERVICE'],
             'collectionexercise-service': current_app.config['COLLECTION_EXERCISE_SERVICE'],
             'case-service': current_app.config['CASE_SERVICE'],
             'party-service': current_app.config['PARTY_SERVICE']

--- a/config.py
+++ b/config.py
@@ -56,12 +56,12 @@ class Config(object):
                                                       COLLECTION_EXERCISE_HOST,
                                                       COLLECTION_EXERCISE_PORT)
 
-    RM_SURVEY_SERVICE_PROTOCOL = os.getenv('RM_SURVEY_SERVICE_PROTOCOL', 'http')
-    RM_SURVEY_SERVICE_HOST = os.getenv('RM_SURVEY_SERVICE_HOST', 'localhost')
-    RM_SURVEY_SERVICE_PORT = os.getenv('RM_SURVEY_SERVICE_PORT', 8080)
-    RM_SURVEY_SERVICE = '{}://{}:{}'.format(RM_SURVEY_SERVICE_PROTOCOL,
-                                            RM_SURVEY_SERVICE_HOST,
-                                            RM_SURVEY_SERVICE_PORT)
+    SURVEY_SERVICE_PROTOCOL = os.getenv('SURVEY_SERVICE_PROTOCOL', 'http')
+    SURVEY_SERVICE_HOST = os.getenv('SURVEY_SERVICE_HOST', 'localhost')
+    SURVEY_SERVICE_PORT = os.getenv('SURVEY_SERVICE_PORT', 8080)
+    SURVEY_SERVICE = '{}://{}:{}'.format(SURVEY_SERVICE_PROTOCOL,
+                                         SURVEY_SERVICE_HOST,
+                                         SURVEY_SERVICE_PORT)
 
     PARTY_SERVICE_PROTOCOL = os.getenv('PARTY_SERVICE_PROTOCOL', 'http')
     PARTY_SERVICE_HOST = os.getenv('PARTY_SERVICE_HOST', 'localhost')


### PR DESCRIPTION
# Motivation and Context
This change sets all the environment variables consistent across all the services to alleviate confusion when adding new functionality. This will also remove confusion for migration.

# What has changed
All environment variables that have the prefix RM or RAS the prefix has been removed.

# How to test?
Run the tests as normal using make test to ensure no tests have been broken through the renaming process.

# Links
https://trello.com/c/3FBH3nNx
