### PR TITLE
Create DNS entries for each service

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -138,19 +138,53 @@ spec:
           - name: ONS_CRYPTOKEY
             value: "{{ .Values.cryptoKey }}"
           - name: COLLECTION_EXERCISE_HOST
+            {{- if .Values.dns.enabled }}
+            value: "collection-exercise.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_HOST)"
+            {{- end }}
           - name: COLLECTION_EXERCISE_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            {{- end }}
           - name: CASE_SERVICE_HOST
+            {{- if .Values.dns.enabled }}
+            value: "case.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(CASE_SERVICE_HOST)"
+            {{- end }}
           - name: CASE_SERVICE_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(CASE_SERVICE_PORT)"
+            {{- end }}
           - name: PARTY_SERVICE_HOST
+            {{- if .Values.dns.enabled }}
+            value: "party.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(PARTY_SERVICE_HOST)"
+            {{- end }}
           - name: PARTY_SERVICE_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
             value: "$(PARTY_SERVICE_PORT)"
-          - name: RM_SURVEY_SERVICE_HOST
+            {{- end }}
+          - name: SURVEY_SERVICE_HOST
+             {{- if .Values.dns.enabled }}
+            value: "survey.{{ .Values.namespace }}.svc.cluster.local"
+            {{- else }}
             value: "$(SURVEY_SERVICE_HOST)"
+            {{- end }}
+          - name: SURVEY_SERVICE_PORT
+            {{- if .Values.dns.enabled }}
+            value: "{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "$(SURVEY_SERVICE_PORT)"
+            {{- end }}
           - name: RABBITMQ_USERNAME
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/collection-instrument/values.yaml
+++ b/_infra/helm/collection-instrument/values.yaml
@@ -38,3 +38,7 @@ sdx:
     port: "5672"
     username: guest
     password: guest
+
+dns:
+  enabled: false
+  wellKnownPort: 8080


### PR DESCRIPTION
# Motivation and Context
Adds kube_dns addresses for all connecting services to allow us to have circular references