### PR TITLE
Add flag to determine if SDX cluster is external

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.0
+appVersion: 2.0.1

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -244,14 +244,24 @@ spec:
                 key: rabbitmq-password
             {{- end }}
           - name: SDX_RABBITMQ_HOST
-            {{- if .Values.sdx.rabbitMQ.enabled }}
+            {{- if and .Values.sdx.rabbitMQ.enabled .Values.sdx.rabbitMQ.external }}
             value: "{{ .Values.sdx.rabbitMQ.host }}"
+            {{- else if .Values.sdx.rabbitMQ.enabled }}
+            valueFrom:
+              configMapKeyRef:
+                  name: rabbit-config
+                  key: rabbit-mq-host
             {{- else }}
             value: "$(RABBITMQ_SERVICE_HOST)"
             {{- end }}
           - name: SDX_RABBITMQ_PORT
-            {{- if .Values.sdx.rabbitMQ.enabled }}
+            {{- if and .Values.sdx.rabbitMQ.enabled .Values.sdx.rabbitMQ.external }}
             value: "{{ .Values.sdx.rabbitMQ.port }}"
+            {{- else if .Values.managedRabbitMQ.enabled }}
+            valueFrom:
+              configMapKeyRef:
+                  name: rabbit-config
+                  key: rabbit-mq-port
             {{- else }}
             value: "$(RABBITMQ_SERVICE_PORT)"
             {{- end }}

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -249,8 +249,8 @@ spec:
             {{- else if .Values.sdx.rabbitMQ.enabled }}
             valueFrom:
               configMapKeyRef:
-                  name: rabbit-config
-                  key: rabbit-mq-host
+                name: rabbit-config
+                key: rabbit-mq-host
             {{- else }}
             value: "$(RABBITMQ_SERVICE_HOST)"
             {{- end }}
@@ -260,8 +260,8 @@ spec:
             {{- else if .Values.managedRabbitMQ.enabled }}
             valueFrom:
               configMapKeyRef:
-                  name: rabbit-config
-                  key: rabbit-mq-port
+                name: rabbit-config
+                key: rabbit-mq-port
             {{- else }}
             value: "$(RABBITMQ_SERVICE_PORT)"
             {{- end }}

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
                 name: rabbitmq
                 key: rabbitmq-password
           - name: RABBITMQ_HOST
-            {{- if .Values.managedRabbitMQ.enabled }}
+            {{- if .Values.managedRabbitMQ.enabled  }}
             valueFrom:
                 configMapKeyRef:
                     name: rabbit-config
@@ -220,7 +220,7 @@ spec:
           - name: RABBITMQ_AMQP_COLLECTION_INSTRUMENT
             value: "amqp://$(RABBITMQ_USERNAME):$(RABBITMQ_PASSWORD)@$(RABBITMQ_HOST):$(RABBITMQ_PORT)"
           - name: SDX_RABBITMQ_USERNAME
-            {{- if .Values.sdx.rabbitMQ.enabled }}
+            {{- if and .Values.sdx.rabbitMQ.enabled .Values.sdx.rabbitMQ.external }}
             valueFrom:
               secretKeyRef:
                 name: sdx-rabbitmq
@@ -232,7 +232,7 @@ spec:
                 key: rabbitmq-username
             {{- end }}
           - name: SDX_RABBITMQ_PASSWORD
-            {{- if .Values.sdx.rabbitMQ.enabled }}
+            {{- if and .Values.sdx.rabbitMQ.enabled .Values.sdx.rabbitMQ.external }}
             valueFrom:
               secretKeyRef:
                 name: sdx-rabbitmq

--- a/_infra/helm/collection-instrument/values.yaml
+++ b/_infra/helm/collection-instrument/values.yaml
@@ -36,6 +36,7 @@ managedRabbitMQ:
 sdx:
   rabbitMQ:
     enabled: false
+    external: true
     host: "127.0.0.1"
     port: "5672"
     username: guest


### PR DESCRIPTION
Update Helm chart with a flag to determine if the SDX rabbit cluster is external.

In preprod and prod the rabbit cluster used for RASRM-SDX traffic is external and hosted outside of our kubernetes cluster, so we need to use different connection details.

In the performance environment, we need to use the same Rabbit cluster in the rabbit namespace for RASRM-SDX that RASRM uses for internal communication.

All other environments will use a Rabbit service deployed in their own namespace.

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
