### PR TITLE
Add structlog processor for Google Cloud Logging

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.1
+appVersion: 2.0.2

--- a/application/logger_config.py
+++ b/application/logger_config.py
@@ -47,7 +47,17 @@ def logger_initial_config(service_name=None,
         event_dict['parent'] = g._zipkin_span.zipkin_attrs.parent_span_id
         return event_dict
 
+    def add_severity_level(logger, method_name, event_dict):
+        """
+        Add the log level to the event dict.
+        """
+        if method_name == "warn":
+            # The stdlib has an alias
+            method_name = "warning"
+
+        event_dict["severity"] = method_name
+
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[zipkin_ids, add_log_level, filter_by_level, add_service,
+    configure(processors=[add_severity_level, add_log_level, filter_by_level, add_service,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
                           JSONRenderer(indent=indent)])

--- a/application/logger_config.py
+++ b/application/logger_config.py
@@ -2,8 +2,6 @@ import logging
 import os
 import sys
 
-import flask
-from flask import g
 from structlog import configure
 from structlog.processors import JSONRenderer, TimeStamper
 from structlog.stdlib import add_log_level, filter_by_level

--- a/application/logger_config.py
+++ b/application/logger_config.py
@@ -56,6 +56,7 @@ def logger_initial_config(service_name=None,
             method_name = "warning"
 
         event_dict["severity"] = method_name
+        return event_dict
 
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
     configure(processors=[add_severity_level, add_log_level, filter_by_level, add_service,

--- a/application/logger_config.py
+++ b/application/logger_config.py
@@ -34,19 +34,6 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
-    def zipkin_ids(logger, method_name, event_dict):
-        event_dict['trace'] = ''
-        event_dict['span'] = ''
-        event_dict['parent'] = ''
-        if not flask.has_app_context():
-            return event_dict
-        if '_zipkin_span' not in g:
-            return event_dict
-        event_dict['span'] = g._zipkin_span.zipkin_attrs.span_id
-        event_dict['trace'] = g._zipkin_span.zipkin_attrs.trace_id
-        event_dict['parent'] = g._zipkin_span.zipkin_attrs.parent_span_id
-        return event_dict
-
     def add_severity_level(logger, method_name, event_dict):
         """
         Add the log level to the event dict.


### PR DESCRIPTION
# Motivation and Context
Added "severity level" processor to structlog, so Google Cloud Logging can parse severity
<!--- Why is this change required? What problem does it solve? -->

# What has changed
New structlog processor defined in logger config, replacing obsolete zipkin processor
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
locally: pipenv run tox

dev: Spin up cluster in Dev, with pod built from image tag "cloud-logging"; generate error; check Stackdriver logs for correct parsing and severity levels

<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/wDSxYgCQ
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
