### PR TITLE
Add duplicate classifier protection

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.19
+appVersion: 2.0.20

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -162,11 +162,12 @@ class CollectionInstrument(object):
         instrument.survey = survey
 
         if classifiers:
-            instruments = self._get_instruments_by_classifier(loads(classifiers), None, session)
+            deserialized_classifiers = loads(classifiers)
+            instruments = self._get_instruments_by_classifier(deserialized_classifiers, None, session)
             for instrument in instruments:
-                if instrument.classifiers == loads(classifiers):
+                if instrument.classifiers == deserialized_classifiers:
                     raise RasError("Cannot upload an instrument with an identical set of classifiers", 400)
-            instrument.classifiers = loads(classifiers)
+            instrument.classifiers = deserialized_classifiers
 
         session.add(instrument)
 

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -162,6 +162,10 @@ class CollectionInstrument(object):
         instrument.survey = survey
 
         if classifiers:
+            instruments = self._get_instruments_by_classifier(loads(classifiers), None, session)
+            for instrument in instruments:
+                if instrument.classifiers == loads(classifiers):
+                    raise RasError("Cannot upload an instrument with an identical set of classifiers", 400)
             instrument.classifiers = loads(classifiers)
 
         session.add(instrument)

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -77,6 +77,36 @@ class TestCollectionInstrumentView(TestClient):
 
         self.assertEqual(len(collection_instruments()), 2)
 
+    def test_upload_collection_instrument_without_collection_exercise_duplicate_protection(self):
+
+        # When a post is made to the upload end point
+        response = self.client.post(
+            '/collection-instrument-api/1.0.2/upload?survey_id=cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+            '&classifiers=%7B%22form_type%22%3A%220255%22%2C%22eq_id%22%3A%22rsi%22%7D',
+            headers=self.get_auth_headers(),
+            content_type='multipart/form-data')
+
+        # Then CI uploads successfully
+        self.assertStatus(response, 200)
+        self.assertEqual(response.data.decode(), UPLOAD_SUCCESSFUL)
+
+        self.assertEqual(len(collection_instruments()), 2)
+
+        # When a post is made to the upload end point
+        response = self.client.post(
+            '/collection-instrument-api/1.0.2/upload?survey_id=cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+            '&classifiers=%7B%22form_type%22%3A%220255%22%2C%22eq_id%22%3A%22rsi%22%7D',
+            headers=self.get_auth_headers(),
+            content_type='multipart/form-data')
+
+        # Then the file upload fails
+        error = {
+            "errors": ["Cannot upload an instrument with an identical set of classifiers"]
+        }
+        self.assertStatus(response, 400)
+        self.assertEqual(response.json, error)
+        self.assertEqual(len(collection_instruments()), 2)
+
     def test_upload_collection_instrument_if_survey_does_not_exist(self):
 
         # When a post is made to the upload end point

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -92,7 +92,7 @@ class TestCollectionInstrumentView(TestClient):
 
         self.assertEqual(len(collection_instruments()), 2)
 
-        # When a post is made to the upload end point
+        # When a post is made to the upload end point with identical classifiers
         response = self.client.post(
             '/collection-instrument-api/1.0.2/upload?survey_id=cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
             '&classifiers=%7B%22form_type%22%3A%220255%22%2C%22eq_id%22%3A%22rsi%22%7D',
@@ -106,6 +106,19 @@ class TestCollectionInstrumentView(TestClient):
         self.assertStatus(response, 400)
         self.assertEqual(response.json, error)
         self.assertEqual(len(collection_instruments()), 2)
+
+        # When a post is made to the upload end point for the same survey with the same eq_id but different formtype
+        response = self.client.post(
+            '/collection-instrument-api/1.0.2/upload?survey_id=cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+            '&classifiers=%7B%22form_type%22%3A%220266%22%2C%22eq_id%22%3A%22rsi%22%7D',
+            headers=self.get_auth_headers(),
+            content_type='multipart/form-data')
+
+        # Then CI uploads successfully
+        self.assertStatus(response, 200)
+        self.assertEqual(response.data.decode(), UPLOAD_SUCCESSFUL)
+
+        self.assertEqual(len(collection_instruments()), 3)
 
     def test_upload_collection_instrument_if_survey_does_not_exist(self):
 


### PR DESCRIPTION
# Motivation and Context
Previously there weren't any checks to make sure that duplication wasn't happening when uploading collection instruments (especially around EQ).  This adds a check so  if you're uploading an instrument for a survey only, and ALL the collection instruments are the same then it'll raise an error as it's a duplicate

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
