### PR TITLE
Add flag to surpress warning

### DIFF
--- a/application/models/__init__.py
+++ b/application/models/__init__.py
@@ -16,6 +16,7 @@ class GUID(TypeDecorator):
     CHAR(32), storing as stringified hex values.
     """
     impl = CHAR
+    cache_ok = True
 
     @staticmethod
     def load_dialect_impl(dialect):


### PR DESCRIPTION
# What and why?

There was an error line that appeared when collection-instrument starts:
```
/app/application/controllers/sql_queries.py:17: SAWarning: TypeDecorator GUID() will not produce a cache key because the ``cache_ok`` flag is not set to True.  Set this flag to True if this type object's state is safe to use in a cache key, or False to disable this warning.
```

Looking at the identical example found in https://docs.sqlalchemy.org/en/14/core/custom_types.html#backend-agnostic-guid-type (where this code most likely originated), it's been updated with a `cache_ok = True` value.

# How to test?

# Trello
