### PR TITLE
remove app.ctx DO NOT MERGE

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.8
+appVersion: 2.1.9

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ import os
 import structlog
 from alembic import command
 from alembic.config import Config
-from flask import Flask, _app_ctx_stack
+from flask import Flask
 from flask_cors import CORS
 from pika.exceptions import AMQPConnectionError
 from retrying import RetryError, retry
@@ -72,11 +72,9 @@ def create_app(config=None, init_db=True, init_rabbit=True):
 def create_database(db_connection, db_schema):
     from application.models import models
 
-    def current_request():
-        return _app_ctx_stack.__ident_func__()
-
     engine = create_engine(db_connection)
-    session = scoped_session(sessionmaker(), scopefunc=current_request)
+    session_factory = sessionmaker(bind=engine)
+    session = scoped_session(session_factory)
     session.configure(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
     engine.session = session
 


### PR DESCRIPTION
# What and why?
Unit tests are failing due to deprecated method in flask.
# How to test?
should be able to test locally and in own namespace
# Trello
https://trello.com/c/0uQlMX9V/735-s38-remove-deprecated-call-to-function-in-ras-collection-instrument