### PR TITLE
Update chart version automatically

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
           export CHART_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
           echo "appVersion: $APP_VERSION"
           echo "chartVersion: $CHART_VERSION"
-          if [ ${{ steps.vars.outputs.tag }} = $APP_VERSION ] || ${{ steps.vars.outputs.tag }} = $CHART_VERSION; then
+          if [ ${{ steps.vars.outputs.tag }} = $APP_VERSION ]; then
             echo "versions match, incrementing patch"
             OLD_PATCH=$(echo ${{ steps.vars.outputs.tag }} | cut -d '.' -f3)
             echo "OLD patch: $OLD_PATCH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,6 @@ jobs:
             echo "New patch version: $NEW_PATCH"
             NEW_APP_VERSION="appVersion: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
             NEW_CHART_VERSION="version: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
-            echo "new version: $NEW_VERSION"
             sed -i -e "s/appVersion: .*/$NEW_APP_VERSION/g" $CHART_DIRECTORY/Chart.yaml
             sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
 
@@ -108,8 +107,27 @@ jobs:
 
             git push
           else
-            echo "git version and the chart and app versions do not match"
-            echo "Using current version: $APP_VERSION"
+            if [ $APP_VERSION != $CHART_VERSION ]; then
+              echo "app version manually updated without updating chart version"
+              NEW_CHART_VERSION="version: $(echo $CHART_VERSION | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+              sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
+
+              git config user.name "ras-rm-pr-bot"
+              git config user.email "${{ secrets.BOT_EMAIL }}"
+
+              git remote set-url origin https://ras-rm-pr-bot:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+
+              git remote update
+              git fetch
+              git checkout ${{ github.head_ref }}
+              git add $CHART_DIRECTORY/Chart.yaml
+              git commit -m "$COMMIT_MSG"
+
+              git push
+            else
+              echo "git version different to chart/app versions and chart/app versions match"
+              echo "Using current version: $APP_VERSION"
+            fi
           fi
 
       - name: output new version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,27 +64,13 @@ jobs:
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
-    
-      - name: package helm
-        run: |
-          echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
-          helm dep up $CHART_DIRECTORY
-          helm package $CHART_DIRECTORY
-
-      - name: Publish dev Chart
-        if: github.ref != 'refs/heads/main'
-        run: |
-          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
-          gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
-
       - name: Set current tag
         if: github.ref != 'refs/heads/main'
         id: vars
         run: |
           git fetch --tags
           echo ::set-output name=tag::$(git describe --tags --abbrev=0)
-
-      - name: update version
+      - name: update versions
         if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
@@ -94,16 +80,20 @@ jobs:
         run: |
           echo "Current git version: ${{ steps.vars.outputs.tag }}"
           export APP_VERSION=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
+          export CHART_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
           echo "appVersion: $APP_VERSION"
-          if [ ${{ steps.vars.outputs.tag }} = $APP_VERSION ]; then
+          echo "chartVersion: $CHART_VERSION"
+          if [ ${{ steps.vars.outputs.tag }} = $APP_VERSION ] || ${{ steps.vars.outputs.tag }} = $CHART_VERSION; then
             echo "versions match, incrementing patch"
             OLD_PATCH=$(echo ${{ steps.vars.outputs.tag }} | cut -d '.' -f3)
             echo "OLD patch: $OLD_PATCH"
             NEW_PATCH=$(($OLD_PATCH + 1))
             echo "New patch version: $NEW_PATCH"
-            NEW_VERSION="appVersion: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+            NEW_APP_VERSION="appVersion: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+            NEW_CHART_VERSION="version: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
             echo "new version: $NEW_VERSION"
-            sed -i -e "s/appVersion: .*/$NEW_VERSION/g" $CHART_DIRECTORY/Chart.yaml
+            sed -i -e "s/appVersion: .*/$NEW_APP_VERSION/g" $CHART_DIRECTORY/Chart.yaml
+            sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
 
             git config user.name "ras-rm-pr-bot"
             git config user.email "${{ secrets.BOT_EMAIL }}"
@@ -118,8 +108,8 @@ jobs:
 
             git push
           else
-            echo "git version and appVersion do not not match"
-            echo "Using current appVersion: $APP_VERSION"
+            echo "git version and the chart and app versions do not match"
+            echo "Using current version: $APP_VERSION"
           fi
 
       - name: output new version
@@ -128,6 +118,18 @@ jobs:
         shell: bash
         run: |
           echo ::set-output name=version::$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
+    
+      - name: package helm
+        run: |
+          echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
+          helm dep up $CHART_DIRECTORY
+          helm package $CHART_DIRECTORY
+
+      - name: Publish dev Chart
+        if: github.ref != 'refs/heads/main'
+        run: |
+          mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
+          gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,36 +93,29 @@ jobs:
             NEW_CHART_VERSION="version: $(echo ${{ steps.vars.outputs.tag }} | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
             sed -i -e "s/appVersion: .*/$NEW_APP_VERSION/g" $CHART_DIRECTORY/Chart.yaml
             sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
-
             git config user.name "ras-rm-pr-bot"
             git config user.email "${{ secrets.BOT_EMAIL }}"
-
             git remote set-url origin https://ras-rm-pr-bot:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
             git remote update
             git fetch
             git checkout ${{ github.head_ref }}
             git add $CHART_DIRECTORY/Chart.yaml
             git commit -m "$COMMIT_MSG"
-
             git push
           else
             if [ $APP_VERSION != $CHART_VERSION ]; then
               echo "app version manually updated without updating chart version"
-              NEW_CHART_VERSION="version: $(echo $CHART_VERSION | sed -e "s/[0-9]\{1,3\}/$NEW_PATCH/3")"
+              NEW_CHART_VERSION="version: $APP_VERSION"
+              echo "replacing version with $NEW_CHART_VERSION"
               sed -i -e "s/version: .*/$NEW_CHART_VERSION/g" $CHART_DIRECTORY/Chart.yaml
-
               git config user.name "ras-rm-pr-bot"
               git config user.email "${{ secrets.BOT_EMAIL }}"
-
               git remote set-url origin https://ras-rm-pr-bot:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
               git remote update
               git fetch
               git checkout ${{ github.head_ref }}
               git add $CHART_DIRECTORY/Chart.yaml
               git commit -m "$COMMIT_MSG"
-
               git push
             else
               echo "git version different to chart/app versions and chart/app versions match"

--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.4
+version: 2.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.9
+appVersion: 2.1.10


### PR DESCRIPTION
# What and why?
Looking at Chart.yaml and the Helm template it contains, apparently we should be incrementing the chart version any time we increment the app version.

This adds auto-increment to the chart version if it hasn't been updated, same as the app version. If the app version has been manually updated but the chart version hasn't been, it'll take the app version as the main source of truth (as this is the one we're most likely to manually update)

# How to test?
This change tests itself on PR :)

# Trello
https://trello.com/c/j0nYtZ5o/758-update-chart-version-at-the-same-time-as-the-app-version