### PR TITLE
Remove unused endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ build-kubernetes:
 	docker build -f _infra/docker/Dockerfile .
 
 lint:
-	pipenv run flake8 ./application ./tests
 	pipenv check ./application ./tests
 	pipenv run isort .
 	pipenv run black --line-length 120 .
+	pipenv run flake8 ./application ./tests
 
 test: lint
 	pipenv run tox

--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.12
+version: 2.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.12
+appVersion: 2.1.13

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -133,16 +133,6 @@ def instrument_data(instrument_id):
     return response
 
 
-@collection_instrument_view.route("/instrument_size/<instrument_id>", methods=["GET"])
-def instrument_size(instrument_id):
-    instrument = CollectionInstrument().get_instrument_json(instrument_id)
-
-    if instrument and "len" in instrument:
-        return make_response(str(instrument["len"]), 200)
-
-    return make_response(COLLECTION_INSTRUMENT_NOT_FOUND, 404)
-
-
 def publish_uploaded_collection_instrument(exercise_id, instrument_id):
     """
     Publish message to collection instrument link

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -250,33 +250,6 @@ paths:
               example: 'adc8dcc1-c35f-4caf-8f5d-93e6287d4872.xlsx'
         '404':
           description: Collection instrument not found
-  "/collection-instrument-api/1.0.2/instrument_size/{instrument_id}":
-    get:
-      summary: Get the size of a collection instrument
-      tags:
-        - collection-instrument
-      parameters:
-        - in: path
-          name: instrument_id
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 'ffb8a5e8-03ef-45f0-a85a-3276e98f66b8'
-          description: The ID of the collection instrument.
-      responses:
-        '200':
-          description: Returned size of collection instrument
-          content:
-            text/plain:
-              schema:
-                type: object
-                properties:
-                  size:
-                    type: integer
-                    example: '52224'
-        '404':
-          description: Collection instrument not found
   "/collection-instrument-api/1.0.2/collectioninstrument/count":
     get:
       summary: Get count of collection instruments

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -487,31 +487,6 @@ class TestCollectionInstrumentView(TestClient):
         self.assertStatus(response, 404)
         self.assertEqual(response.data.decode(), NO_INSTRUMENT_FOR_EXERCISE)
 
-    def test_get_instrument_size(self):
-        # Given an instrument which is in the db
-        # When the collection instrument size end point is called with an id
-        response = self.client.get(
-            "/collection-instrument-api/1.0.2/instrument_size/{instrument_id}".format(instrument_id=self.instrument_id),
-            headers=self.get_auth_headers(),
-        )
-
-        # Then the response returns the correct size
-        self.assertStatus(response, 200)
-        self.assertIn("999", response.data.decode())
-
-    def test_get_instrument_size_missing_instrument(self):
-        # Given an instrument id which doesn't exist in the db
-        instrument = "655488ea-ccaa-4d02-8f73-3d20bceed706"
-
-        # When the collection instrument end point is called with an id
-        response = self.client.get(
-            "/collection-instrument-api/1.0.2/instrument_size/{instrument_id}".format(instrument_id=instrument),
-            headers=self.get_auth_headers(),
-        )
-
-        # Then the response returns a 404
-        self.assertStatus(response, 404)
-
     def test_get_instrument_download(self):
         # Given an instrument which is in the db
         # When the collection instrument end point is called with an id

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ allowlist_externals=flake8
 setenv=APP_SETTINGS=TestingConfig
 
 commands=
-    flake8 .
     black --line-length 120 --check .
     isort . --check-only
+    flake8 .
     docker-compose up -d db
     py.test --cov=application --cov-report html --cov-report term-missing []
     docker-compose down


### PR DESCRIPTION
# What and why?

The `/instrument_size/{instrument_id}` endpoint isn't used by anything so it can be removed.

# How to test?

Acceptance tests pass?

# Trello
