### PR TITLE
Modify api and update docs and tests

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.14
+version: 2.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.14
+appVersion: 2.1.15

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -115,6 +115,8 @@ def count_collection_instruments_by_search_string():
 @collection_instrument_view.route("/<instrument_id>", methods=["GET"])
 @collection_instrument_view.route("/collectioninstrument/id/<instrument_id>", methods=["GET"])
 def collection_instrument_by_id(instrument_id):
+    # The /collectioninstrument/id/<id> endpoint needs to be removed once things that call it are replaced by
+    # the simpler /<id> call above it
     instrument_json = CollectionInstrument().get_instrument_json(instrument_id)
 
     if instrument_json:

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -112,6 +112,7 @@ def count_collection_instruments_by_search_string():
     return make_response(str(len(instruments)), 200)
 
 
+@collection_instrument_view.route("/<instrument_id>", methods=["GET"])
 @collection_instrument_view.route("/collectioninstrument/id/<instrument_id>", methods=["GET"])
 def collection_instrument_by_id(instrument_id):
     instrument_json = CollectionInstrument().get_instrument_json(instrument_id)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -274,6 +274,81 @@ paths:
                   count:
                     type: integer
                     example: '123'
+  "/collection-instrument-api/1.0.2/{instrument_id}":
+    get:
+      summary: Get collection instrument by instrument ID
+      tags:
+        - collection-instrument
+      parameters:
+        - in: path
+          name: instrument_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'ffb8a5e8-03ef-45f0-a85a-3276e98f66b8'
+          description: The ID of the collection instrument.
+      responses:
+        '200':
+          description: Returns the collection instrument matching the instrument ID
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  classifiers:
+                    type: string
+                    format: dictionary
+                    example: '"COLLECTION_EXERCISE": ["8f078c99-2843-47c6-9c57-13e5966fbc9e"]'
+                  form_type:
+                    type: string
+                    format: dictionary
+                    example: '"form_type": "001","RU_REF": ["test_ru_ref"]'
+                  file_name:
+                    type: string
+                    example: 'file_name'
+                  id:
+                    type: string
+                    format: uuid
+                    example: '7574283a-d1fd-49df-b684-d7b201e5748a'
+                  surveyId:
+                    type: string
+                    format: uuid
+                    example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+        '404':
+          description: Collection instrument not found
+    patch:
+      summary: Patch collection instrument by instrument ID
+      tags:
+        - collection-instrument
+      parameters:
+        - in: path
+          name: instrument_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'ffb8a5e8-03ef-45f0-a85a-3276e98f66b8'
+          description: The ID of the collection instrument.
+      responses:
+        '200':
+          description: Returns the collection instrument matching the instrument ID
+          content:
+            text/plain:
+                schema:
+                  type: string
+                  example: "The patch of the instrument was successful"
+        '400':
+          description: Request error (not found, missing filename, not a seft instrument)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    format: dictionary
+                    example: ["Missing filename"]
   "/collection-instrument-api/1.0.2/collectioninstrument":
     get:
       summary: Get collection instrument by search string

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -468,6 +468,18 @@ class TestCollectionInstrumentView(TestClient):
         self.assertIn("test_ru_ref", response.data.decode())
         self.assertIn("cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", response.data.decode())
 
+        # Given an instrument which is in the db
+        # When the collection instrument end point is called with an id
+        response = self.client.get(
+            "/collection-instrument-api/1.0.2/{instrument_id}".format(instrument_id=self.instrument_id),
+            headers=self.get_auth_headers(),
+        )
+
+        # Then the response returns the correct data
+        self.assertStatus(response, 200)
+        self.assertIn("test_ru_ref", response.data.decode())
+        self.assertIn("cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", response.data.decode())
+
     def test_get_instrument_by_id_no_instrument(self):
         # Given a instrument which doesn't exist
         missing_instrument_id = "ffb8a5e8-03ef-45f0-a85a-3276e98f66b8"
@@ -477,6 +489,16 @@ class TestCollectionInstrumentView(TestClient):
             "/collection-instrument-api/1.0.2/collectioninstrument/id/{instrument_id}".format(
                 instrument_id=missing_instrument_id
             ),
+            headers=self.get_auth_headers(),
+        )
+
+        # Then the response returns no data
+        self.assertStatus(response, 404)
+        self.assertEqual(response.data.decode(), COLLECTION_INSTRUMENT_NOT_FOUND)
+
+        # When the collection instrument end point is called with an id
+        response = self.client.get(
+            "/collection-instrument-api/1.0.2/{instrument_id}".format(instrument_id=missing_instrument_id),
             headers=self.get_auth_headers(),
         )
 


### PR DESCRIPTION
# What and why?

The collection instrument api had a weird `/collectioninstrument/id/<id>` endpoint to get the collection instrument and should be replaced with a simpler `/<id>` endpoint (like we do for PATCH).  This PR adds the shortened version (whilst leaving the  original for backwards compatibility), updates the API docs and the tests to reflect this change.

# How to test?

# Trello
