### PR TITLE
Seft ci validation

### DIFF
--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -16,8 +16,8 @@ from application.controllers.sql_queries import (
     query_business_by_ru,
     query_exercise_by_id,
     query_instrument,
-    query_instrument_by_id,
     query_instrument_by_exercise_id,
+    query_instrument_by_id,
     query_survey_by_id,
 )
 from application.exceptions import RasError
@@ -100,7 +100,7 @@ class CollectionInstrument(object):
         exercise = self._find_or_create_exercise(exercise_id, session)
         instrument.exercises.append(exercise)
 
-        self.validate_nonduplicate_instrument(instrument, session)
+        self.validate_non_duplicate_instrument(instrument, session)
 
         survey = self._find_or_create_survey_from_exercise_id(exercise_id, session)
         instrument.survey = survey
@@ -140,7 +140,7 @@ class CollectionInstrument(object):
         exercise = self._find_or_create_exercise(exercise_id, session)
         instrument.exercises.append(exercise)
 
-        self.validate_nonduplicate_instrument(instrument, session)
+        self.validate_non_duplicate_instrument(instrument, session)
 
         survey = self._find_or_create_survey_from_exercise_id(exercise_id, session)
         instrument.survey = survey
@@ -167,7 +167,7 @@ class CollectionInstrument(object):
         return instrument
 
     @staticmethod
-    def validate_nonduplicate_instrument(instrument, session):
+    def validate_non_duplicate_instrument(instrument, session):
         instruments = query_instrument_by_exercise_id(instrument.exids[0], session)
 
         for i in instruments:

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -172,8 +172,8 @@ class CollectionInstrument(object):
 
         for i in instruments:
             if i.seft_file.file_name == instrument.seft_file.file_name:
-                log.error('SEFT collection instrument file already uploaded for this collection exercise')
-                raise RasError('Collection instrument already uploaded', 400)
+                log.error("SEFT collection instrument file already uploaded for this collection exercise")
+                raise RasError("Collection instrument already uploaded", 400)
 
         return
 

--- a/application/controllers/sql_queries.py
+++ b/application/controllers/sql_queries.py
@@ -24,3 +24,6 @@ def query_instrument_by_id(instrument_id, session):
 
 def query_instrument(session):
     return session.query(InstrumentModel)
+
+def query_instrument_by_exercise_id(exercise_id, session):
+    return session.query(InstrumentModel).filter(InstrumentModel.exids[0] == exercise_id)

--- a/application/controllers/sql_queries.py
+++ b/application/controllers/sql_queries.py
@@ -25,5 +25,6 @@ def query_instrument_by_id(instrument_id, session):
 def query_instrument(session):
     return session.query(InstrumentModel)
 
+
 def query_instrument_by_exercise_id(exercise_id, session):
-    return session.query(InstrumentModel).filter(InstrumentModel.exids[0] == exercise_id)
+    return session.query(InstrumentModel).filter(InstrumentModel.exids == exercise_id)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ allowlist_externals=flake8
 setenv=APP_SETTINGS=TestingConfig
 
 commands=
-
+    black --line-length 120 --check .
     isort . --check-only
     flake8 .
     docker-compose up -d db

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ allowlist_externals=flake8
 setenv=APP_SETTINGS=TestingConfig
 
 commands=
-    black --line-length 120 --check .
+
     isort . --check-only
     flake8 .
     docker-compose up -d db


### PR DESCRIPTION
# What and why?
This service needs validation when uploading SEFT CIs so that the user can't upload 2 files with the same name for the same collection exercise.
# How to test?
Try to upload 2 identically-named files for a given collection exercise.

# Trello
[Card](https://trello.com/c/WUMnS5pl)