### PR TITLE
Remove seft data column

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.35
+version: 2.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.35
+appVersion: 2.1.36

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -94,7 +94,7 @@ class CollectionInstrument(object):
         self.validate_non_duplicate_instrument(file, exercise_id, session)
         instrument = InstrumentModel(ci_type="SEFT")
 
-        seft_file = self._create_seft_file(instrument.instrument_id, file, encrypt_and_save_to_db=False)
+        seft_file = self._create_seft_file(instrument.instrument_id, file)
         instrument.seft_file = seft_file
 
         exercise = self._find_or_create_exercise(exercise_id, session)
@@ -384,7 +384,7 @@ class CollectionInstrument(object):
         return business
 
     @staticmethod
-    def _create_seft_file(instrument_id, file, encrypt_and_save_to_db=True):
+    def _create_seft_file(instrument_id, file):
         """
         Creates a seft_file with an encrypted version of the file
         :param file: A file object from which we can read the file contents
@@ -394,10 +394,6 @@ class CollectionInstrument(object):
         file_contents = file.read()
         file_size = len(file_contents)
         seft_file = SEFTModel(instrument_id=instrument_id, file_name=file.filename, length=file_size)
-        if encrypt_and_save_to_db:
-            cryptographer = Cryptographer()
-            encrypted_file = cryptographer.encrypt(file_contents)
-            seft_file.data = encrypted_file
 
         return seft_file
 

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 from sqlalchemy import Column, ForeignKey, Integer, Table
 from sqlalchemy.dialects.postgresql.json import JSONB
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import deferred, relationship
-from sqlalchemy.types import TIMESTAMP, Boolean, LargeBinary, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import TIMESTAMP, Boolean, String
 
 from application.models import GUID
 

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -164,7 +164,6 @@ class SEFTModel(Base):
 
     id = Column(Integer, primary_key=True)
     file_name = Column(String(32))
-    data = deferred(Column(LargeBinary))
     len = Column(Integer)
     instrument_id = Column(GUID, ForeignKey("instrument.instrument_id"))
     gcs = Column(Boolean)
@@ -176,5 +175,4 @@ class SEFTModel(Base):
         self.instrument_id = instrument_id
         self.file_name = file_name
         self.len = length
-        self.data = data
         self.gcs = False

--- a/migrations/versions/497436b61d0c_remove_seft_data_column.py
+++ b/migrations/versions/497436b61d0c_remove_seft_data_column.py
@@ -17,8 +17,8 @@ depends_on = None
 
 
 def upgrade():
-    op.drop_column("instrument", "data", schema="ras_ci")
+    op.drop_column("seft_instrument", "data", schema="ras_ci")
 
 
 def downgrade():
-    op.add_column("instrument", sa.Column("data", postgresql.BYTEA(), nullable=True), schema="ras_ci")
+    op.add_column("seft_instrument", sa.Column("data", postgresql.BYTEA(), nullable=True), schema="ras_ci")

--- a/migrations/versions/497436b61d0c_remove_seft_data_column.py
+++ b/migrations/versions/497436b61d0c_remove_seft_data_column.py
@@ -1,0 +1,24 @@
+"""Remove SEFT data column
+
+Revision ID: 497436b61d0c
+Revises: e2012ed329da
+Create Date: 2022-08-02 14:34:23.676426
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "497436b61d0c"
+down_revision = "e2012ed329da"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("instrument", "data", schema="ras_ci")
+
+
+def downgrade():
+    op.add_column("instrument", sa.Column("data", postgresql.BYTEA(), nullable=True), schema="ras_ci")

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -565,18 +565,6 @@ class TestCollectionInstrumentView(TestClient):
         self.assertStatus(response, 404)
         self.assertEqual(response.data.decode(), NO_INSTRUMENT_FOR_EXERCISE)
 
-    def test_get_instrument_download(self):
-        # Given an instrument which is in the db
-        # When the collection instrument end point is called with an id
-        response = self.client.get(
-            f"/collection-instrument-api/1.0.2/download/{self.instrument_id}",
-            headers=self.get_auth_headers(),
-        )
-
-        # Then the response returns the correct instrument
-        self.assertStatus(response, 200)
-        self.assertIn("test data", response.data.decode())
-
     def test_get_instrument_download_missing_instrument(self):
         # Given an instrument which doesn't exist in the db
         instrument = "655488ea-ccaa-4d02-8f73-3d20bceed706"


### PR DESCRIPTION
# What and why?
This removes the data column in the SEFT table, as this is now being stored in buckets.

# How to test?

# Trello
https://trello.com/c/0a1C3Vb0/1499-delete-encrypted-instruments-from-collection-instrument-database