### PR TITLE
Add type to collection instrument type

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.8
+version: 3.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.8
+appVersion: 3.0.9

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -68,6 +68,7 @@ class CollectionInstrument(object):
             instrument_json = {
                 "id": instrument.instrument_id,
                 "file_name": instrument.name,
+                "type": instrument.type,
                 "classifiers": {**classifiers, **ru, **collection_exercise},
                 "surveyId": instrument.survey.survey_id,
             }

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -129,7 +129,7 @@ class CollectionInstrument(object):
         log.info("Validating if instrument is already uploaded for this exercise", exercise_id=exercise_id)
         if exercise:
             for i in exercise.instruments:
-                if i.seft_file.file_name == file.filename:
+                if i.type == "SEFT" and i.seft_file.file_name == file.filename:
                     log.info(
                         "Collection instrument file already uploaded for this collection exercise",
                         exercise_id=exercise_id,


### PR DESCRIPTION
# What and why?
For the multimode changes we need to find out the explicit type of survey, this just adds it to the payload. It also adjusts the filename check to just be SEFT, eQ doesn't have filenames and when there are both eQ and SEFT CIs associated to a CE this would fall over without it

# How to test?
To test in conjunction with https://github.com/ONSdigital/response-operations-ui/pull/833
# Trello
