### PR TITLE
Add collection instrument form type check eq and seft

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.9
+version: 3.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.9
+appVersion: 3.0.10

--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.8
+version: 3.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.8
+appVersion: 3.0.9

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from application.controllers.helper import validate_uuid
 from application.controllers.service_helper import (
     collection_instrument_link,
-    get_survey_ref,
+    get_survey_service_details,
     service_request,
 )
 from application.controllers.session_decorator import with_db_session
@@ -17,6 +17,7 @@ from application.controllers.sql_queries import (
     query_exercise_by_id,
     query_instrument,
     query_instrument_by_id,
+    query_instruments_form_type_with_different_survey_mode,
     query_survey_by_id,
 )
 from application.exceptions import RasError
@@ -76,9 +77,9 @@ class CollectionInstrument(object):
         return result
 
     @with_db_session
-    def upload_to_bucket(self, exercise_id, file, ru_ref=None, classifiers=None, session=None):
+    def upload_seft_to_bucket(self, exercise_id, file, ru_ref=None, classifiers=None, session=None):
         """
-        Encrypt and upload a collection instrument to the bucket and db
+        Encrypt and upload a SEFT collection instrument to the bucket and db
 
         :param exercise_id: An exercise id (UUID)
         :param ru_ref: The name of the file we're receiving
@@ -87,41 +88,41 @@ class CollectionInstrument(object):
         :param session: database session
         :return: a collection instrument instance
         """
-
-        log.info("Upload exercise", exercise_id=exercise_id)
+        log.info("Upload instrument", exercise_id=exercise_id)
 
         validate_uuid(exercise_id)
         self.validate_non_duplicate_instrument(file, exercise_id, session)
-        instrument = InstrumentModel(ci_type="SEFT")
-
-        seft_file = self._create_seft_file(instrument.instrument_id, file)
-        instrument.seft_file = seft_file
-
-        exercise = self._find_or_create_exercise(exercise_id, session)
-        instrument.exercises.append(exercise)
 
         survey = self._find_or_create_survey_from_exercise_id(exercise_id, session)
-        instrument.survey = survey
+        survey_id = survey.survey_id
+        survey_service_details = get_survey_service_details(survey_id)
+        ci_type = "SEFT"
+        instrument = InstrumentModel(ci_type=ci_type)
 
+        if classifiers:
+            classifiers = loads(classifiers)
+            if survey_service_details["surveyMode"] == "EQ_AND_SEFT":
+                self.validate_eq_and_seft_form_type(survey_id, classifiers.get("form_type"), ci_type, session)
+            instrument.classifiers = classifiers
+
+        exercise = self._find_or_create_exercise(exercise_id, session)
         if ru_ref:
             business = self._find_or_create_business(ru_ref, session)
             self.validate_one_instrument_for_ru_specific_upload(exercise, business, session)
             instrument.businesses.append(business)
 
-        if classifiers:
-            instrument.classifiers = loads(classifiers)
-
-        try:
-            survey_ref = get_survey_ref(instrument.survey.survey_id)
-            file.filename = survey_ref + "/" + exercise_id + "/" + file.filename
-            seft_ci_bucket = GoogleCloudSEFTCIBucket(current_app.config)
-            seft_ci_bucket.upload_file_to_bucket(file=file)
-        except Exception as e:
-            log.exception("An error occurred when trying to put SEFT CI in bucket")
-            raise e
-
+        seft_file = self._create_seft_file(instrument.instrument_id, file)
+        instrument.seft_file = seft_file
+        instrument.exercises.append(exercise)
+        instrument.survey = survey
         session.add(instrument)
         return instrument
+
+    @staticmethod
+    def validate_eq_and_seft_form_type(survey_id: str, form_type: str, survey_mode: str, session: Session) -> None:
+        instruments = query_instruments_form_type_with_different_survey_mode(survey_id, form_type, survey_mode, session)
+        if instruments:
+            raise RasError(f"This form type has already been used in this survey by {instruments[0].type}", 400)
 
     @staticmethod
     def validate_non_duplicate_instrument(file, exercise_id, session):
@@ -157,7 +158,7 @@ class CollectionInstrument(object):
             log.error("Not a SEFT instrument")
             raise RasError("Not a SEFT instrument", 400)
 
-        survey_ref = get_survey_ref(instrument.survey.survey_id)
+        survey_ref = get_survey_service_details(instrument.survey.survey_id).get("surveyRef")
         exercise_id = str(instrument.exids[0])
 
         seft_model = self._update_seft_file(instrument.seft_file, file, survey_ref, exercise_id)
@@ -209,9 +210,9 @@ class CollectionInstrument(object):
         bound_logger.info("Successfully validated there isn't an instrument for this ru for this exercise")
 
     @with_db_session
-    def upload_instrument_with_no_collection_exercise(self, survey_id, classifiers=None, session=None):
+    def upload_eq(self, survey_id, classifiers=None, session=None):
         """
-        Upload a collection instrument to the db without a collection exercise
+        Upload an eQ collection instrument to the db
 
         :param classifiers: Classifiers associated with the instrument
         :param session: database session
@@ -222,17 +223,24 @@ class CollectionInstrument(object):
         log.info("Upload instrument", survey_id=survey_id)
 
         validate_uuid(survey_id)
-        instrument = InstrumentModel(ci_type="EQ")
-
         survey = self._find_or_create_survey_from_survey_id(survey_id, session)
+        survey_service_details = get_survey_service_details(survey.survey_id)
+
+        ci_type = "EQ"
+        instrument = InstrumentModel(ci_type=ci_type)
         instrument.survey = survey
 
         if classifiers:
-            deserialized_classifiers = loads(classifiers)
+            classifiers = loads(classifiers)
+            if survey_service_details["surveyMode"] == "EQ_AND_SEFT":
+                self.validate_eq_and_seft_form_type(survey.survey_id, classifiers.get("form_type"), ci_type, session)
+
+            deserialized_classifiers = classifiers
             instruments = self._get_instruments_by_classifier(deserialized_classifiers, None, session)
             for instrument in instruments:
                 if instrument.classifiers == deserialized_classifiers:
                     raise RasError("Cannot upload an instrument with an identical set of classifiers", 400)
+
             instrument.classifiers = deserialized_classifiers
 
         session.add(instrument)
@@ -340,6 +348,7 @@ class CollectionInstrument(object):
         :param session: database session
         :return: A survey record
         """
+
         response = service_request(
             service="collectionexercise-service", endpoint="collectionexercises", search_value=exercise_id
         )
@@ -594,6 +603,6 @@ class CollectionInstrument(object):
 
     @staticmethod
     def _build_seft_file_path(instrument) -> str:
-        survey_ref = get_survey_ref(instrument.survey.survey_id)
+        survey_ref = get_survey_service_details(instrument.survey.survey_id).get("surveyRef")
         exercise_id = str(instrument.exids[0])
         return f"{survey_ref}/{exercise_id}/{instrument.seft_file.file_name}"

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -68,6 +68,7 @@ class CollectionInstrument(object):
             instrument_json = {
                 "id": instrument.instrument_id,
                 "file_name": instrument.name,
+                "type": instrument.type,
                 "classifiers": {**classifiers, **ru, **collection_exercise},
                 "surveyId": instrument.survey.survey_id,
             }

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -129,7 +129,7 @@ class CollectionInstrument(object):
         log.info("Validating if instrument is already uploaded for this exercise", exercise_id=exercise_id)
         if exercise:
             for i in exercise.instruments:
-                if i.seft_file.file_name == file.filename:
+                if i.type == "SEFT" and i.seft_file.file_name == file.filename:
                     log.info(
                         "Collection instrument file already uploaded for this collection exercise",
                         exercise_id=exercise_id,

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -4,85 +4,17 @@ import requests
 import structlog
 from flask import current_app
 
-from application.exceptions import RasError
+from application.exceptions import RasError, ServiceUnavailableException
 
 log = structlog.wrap_logger(logging.getLogger(__name__))
 
 
-def get_case_group(case_id):
-    """
-    Get case details from service
-    :param case_id: The case_id to search with
-    :return: case details
-    """
-
-    case_group = None
-    response = service_request(service="case-service", endpoint="cases", search_value=case_id)
-
-    if response.status_code == 200:
-        case = response.json()
-        case_group = case.get("caseGroup")
-    else:
-        log.error("Case not found", case_id=case_id)
-    return case_group
-
-
-def get_collection_exercise(collection_exercise_id):
-    """
-    Get collection exercise details from request
-    :param collection_exercise_id: The collection_exercise_id to search with
-    :return: collection_exercise
-    """
-
-    collection_exercise = None
-    response = service_request(
-        service="collectionexercise-service", endpoint="collectionexercises", search_value=collection_exercise_id
-    )
-
-    if response.status_code == 200:
-        collection_exercise = response.json()
-    else:
-        log.info("Collection Exercise not found", collection_exercise_id=collection_exercise_id)
-    return collection_exercise
-
-
-def get_survey_ref(survey_id):
+def get_survey_service_details(survey_id):
     """
     :param survey_id: The survey_id UUID to search with
     :return: survey reference
     """
-
-    survey_ref = None
     response = service_request(service="survey-service", endpoint="surveys", search_value=survey_id)
-
-    if response.status_code == 200:
-        survey_service_data = response.json()
-        survey_ref = survey_service_data.get("surveyRef")
-    else:
-        log.info("Survey service data not found", survey_id=survey_id)
-
-    return survey_ref
-
-
-def get_business_party(business_id, collection_exercise_id=None, verbose=False):
-    """
-    :param business_id: The business UUID to search with
-    :param collection_exercise_id: The collection exercise id to retrieve attributes for
-    :param verbose: Boolean to decide the verbosity of the party response
-    :return: a business party
-    """
-    log.info("Retrieving business party", party_id=business_id, collection_exercise_id=collection_exercise_id)
-    response = service_request(
-        service="party-service",
-        endpoint="party-api/v1/businesses/id",
-        search_value=f"{business_id}?verbose={verbose}&collection_exercise_id={collection_exercise_id}",
-    )
-
-    if not response.ok:
-        log.error("Failed to find business", party_id=business_id, collection_exercise_id=collection_exercise_id)
-        return None
-
-    log.info("Successfully retrieved business", party_id=business_id, collection_exercise_id=collection_exercise_id)
     return response.json()
 
 
@@ -99,19 +31,26 @@ def service_request(service, endpoint, search_value):
     auth = (current_app.config.get("SECURITY_USER_NAME"), current_app.config.get("SECURITY_USER_PASSWORD"))
 
     try:
-        service = {
+        service_root = {
             "survey-service": current_app.config["SURVEY_URL"],
             "collectionexercise-service": current_app.config["COLLECTION_EXERCISE_URL"],
             "case-service": current_app.config["CASE_URL"],
             "party-service": current_app.config["PARTY_URL"],
         }[service]
-        service_url = f"{service}/{endpoint}/{search_value}"
+        service_url = f"{service_root}/{endpoint}/{search_value}"
         log.info(f"Making request to {service_url}")
     except KeyError:
         raise RasError(f"service '{service}' not configured", 500)
 
-    response = requests.get(service_url, auth=auth)
-    response.raise_for_status()
+    try:
+        response = requests.get(service_url, auth=auth)
+        response.raise_for_status()
+    except requests.HTTPError:
+        raise RasError(f"{service} returned a HTTPError")
+    except requests.ConnectionError:
+        raise ServiceUnavailableException(f"{service} returned a connection error", 503)
+    except requests.Timeout:
+        raise ServiceUnavailableException(f"{service} has timed out", 504)
     return response
 
 

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -9,7 +9,7 @@ from application.exceptions import RasError, ServiceUnavailableException
 log = structlog.wrap_logger(logging.getLogger(__name__))
 
 
-def get_survey_service_details(survey_id):
+def get_survey_details(survey_id):
     """
     :param survey_id: The survey_id UUID to search with
     :return: survey reference

--- a/application/controllers/sql_queries.py
+++ b/application/controllers/sql_queries.py
@@ -27,6 +27,14 @@ def query_instrument(session):
 
 
 def query_instruments_form_type_with_different_survey_mode(survey_id, form_type, survey_mode, session):
+    """
+    query to find instruments which match a given survey_id and form_type but not the survey mode
+    :param survey_id: survey id
+    :param form_type: form type (i.e 0001)
+    :param survey_mode: survey mode (i.e eQ)
+    :param session: session
+    :return: InstrumentModel
+    """
     return (
         session.query(InstrumentModel)
         .join(SurveyModel)

--- a/application/controllers/sql_queries.py
+++ b/application/controllers/sql_queries.py
@@ -24,3 +24,16 @@ def query_instrument_by_id(instrument_id, session):
 
 def query_instrument(session):
     return session.query(InstrumentModel)
+
+
+def query_instruments_form_type_with_different_survey_mode(survey_id, form_type, survey_mode, session):
+    return (
+        session.query(InstrumentModel)
+        .join(SurveyModel)
+        .filter(
+            SurveyModel.survey_id == survey_id,
+            InstrumentModel.classifiers["form_type"].astext == form_type,
+            InstrumentModel.type != survey_mode,
+        )
+        .all()
+    )

--- a/application/exceptions.py
+++ b/application/exceptions.py
@@ -10,6 +10,10 @@ class RasError(Exception):
         return {"errors": self.errors}
 
 
+class ServiceUnavailableException(RasError):
+    pass
+
+
 class RasDatabaseError(RasError):
     pass
 

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -29,10 +29,10 @@ def before_collection_instrument_view():
 
 @collection_instrument_view.route("/upload/<exercise_id>", methods=["POST"])
 @collection_instrument_view.route("/upload/<exercise_id>/<ru_ref>", methods=["POST"])
-def upload_collection_instrument(exercise_id, ru_ref=None):
+def upload_seft_collection_instrument(exercise_id, ru_ref=None):
     file = request.files["file"]
     classifiers = request.args.get("classifiers")
-    instrument = CollectionInstrument().upload_to_bucket(exercise_id, file, ru_ref=ru_ref, classifiers=classifiers)
+    instrument = CollectionInstrument().upload_seft_to_bucket(exercise_id, file, ru_ref=ru_ref, classifiers=classifiers)
 
     if not publish_uploaded_collection_instrument(exercise_id, instrument.instrument_id):
         log.error(
@@ -57,10 +57,10 @@ def patch_collection_instrument(instrument_id):
 
 
 @collection_instrument_view.route("/upload", methods=["POST"])
-def upload_collection_instrument_without_collection_exercise():
+def upload_eq_collection_instrument():
     classifiers = request.args.get("classifiers")
     survey_id = request.args.get("survey_id")
-    CollectionInstrument().upload_instrument_with_no_collection_exercise(survey_id, classifiers=classifiers)
+    CollectionInstrument().upload_eq(survey_id, classifiers=classifiers)
     return make_response(UPLOAD_SUCCESSFUL, 200)
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,6 +59,10 @@ paths:
                     example: 'The upload was successful'
         '500':
           description: Failed to publish upload message
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/upload/{exercise_id}":
     post:
       summary: Encrypt and upload collection instrument associated to collection exercised without RU
@@ -92,6 +96,10 @@ paths:
                     example: 'The upload was successful'
         '500':
           description: Failed to publish upload message
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/upload":
     post:
       summary: Upload an eQ collection instrument associated to a survey with classifiers
@@ -123,6 +131,10 @@ paths:
                     example: 'The upload was successful'
         '500':
           description: Failed to publish upload message
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/link-exercise/{instrument_id}/{exercise_id}":
     post:
       summary: Link a collection instrument to a collection exercise
@@ -228,6 +240,12 @@ paths:
                     example: '2017-10-13 11:25:27.020468'
         '404':
           description: No collection instruments found for collection excercise ID
+        '500':
+          description: An external service returned a HTTPError
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/download/{instrument_id}":
     get:
       summary: Download a collection instrument
@@ -250,6 +268,12 @@ paths:
               example: 'adc8dcc1-c35f-4caf-8f5d-93e6287d4872.xlsx'
         '404':
           description: Collection instrument not found
+        '500':
+          description: An external service returned a HTTPError
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/collectioninstrument/count":
     get:
       summary: Get count of collection instruments
@@ -349,6 +373,12 @@ paths:
                     type: string
                     format: dictionary
                     example: ["Missing filename"]
+        '500':
+          description: An external service returned a HTTPError
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/collection-instrument-api/1.0.2/collectioninstrument":
     get:
       summary: Get collection instrument by search string
@@ -439,6 +469,36 @@ paths:
                     example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
         '404':
           description: Collection instrument not found
+  "/collection-instrument-api/1.0.2/delete/{instrument_id}":
+    delete:
+      summary: Delete a Seft collection instrument
+      tags:
+        - collection-instrument
+      parameters:
+        - in: path
+          name: instrument_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'ffb8a5e8-03ef-45f0-a85a-3276e98f66b8'
+          description: The ID of the collection instrument.
+      responses:
+        '200':
+          description: Successfully deleted the collection instrument
+          content:
+            text/plain:
+                schema:
+                  type: string
+                  example: "SEFT collection instrument deleted successfully"
+        '404':
+          description: Collection instrument not found
+        '500':
+          description: An external service returned a HTTPError
+        '503':
+          description: An external service returned a connection error
+        '504':
+          description: An external service timed out
   "/info":
     get:
       summary: Returns survey information

--- a/tests/controllers/test_service_helper.py
+++ b/tests/controllers/test_service_helper.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
-import json
-from requests.models import Response
+
 import requests
+from requests.models import Response
 
 from application.controllers.service_helper import service_request
 from application.exceptions import RasError, ServiceUnavailableException
@@ -18,9 +18,11 @@ class TestServiceHelper(TestClient):
 
         # When a call is made to the service
         with patch("requests.get", return_value=mock_response):
-            response = service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
+            response = service_request(
+                service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce"
+            )
 
-            # Then it response successfully
+            # Then it response is successful
             self.assertStatus(response, 200)
 
     def test_incorrect_service_request(self):
@@ -40,9 +42,11 @@ class TestServiceHelper(TestClient):
         # Then a RasError is raised
         with patch("requests.get", return_value=mock_response):
             with self.assertRaises(RasError) as exception:
-                service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
+                service_request(
+                    service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce"
+                )
 
-        self.assertEquals(['survey-service returned a HTTPError'], exception.exception.errors)
+        self.assertEquals(["survey-service returned a HTTPError"], exception.exception.errors)
         self.assertEquals(500, exception.exception.status_code)
 
     def test_service_request_connection_error(self):
@@ -51,9 +55,11 @@ class TestServiceHelper(TestClient):
         # Then a ServiceUnavailableException is raised with a 503
         with patch("requests.get", side_effect=requests.ConnectionError):
             with self.assertRaises(ServiceUnavailableException) as exception:
-                service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
+                service_request(
+                    service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce"
+                )
 
-        self.assertEquals(['survey-service returned a connection error'], exception.exception.errors)
+        self.assertEquals(["survey-service returned a connection error"], exception.exception.errors)
         self.assertEquals(503, exception.exception.status_code)
 
     def test_service_request_timeout_error(self):
@@ -63,5 +69,5 @@ class TestServiceHelper(TestClient):
         with patch("requests.get", side_effect=requests.Timeout):
             with self.assertRaises(ServiceUnavailableException) as exception:
                 service_request(service=SERVICE, endpoint="surveys", search_value="test_case")
-        self.assertEquals(['survey-service has timed out'], exception.exception.errors)
+        self.assertEquals(["survey-service has timed out"], exception.exception.errors)
         self.assertEquals(504, exception.exception.status_code)

--- a/tests/controllers/test_service_helper.py
+++ b/tests/controllers/test_service_helper.py
@@ -1,30 +1,67 @@
 from unittest.mock import patch
-
+import json
 from requests.models import Response
+import requests
 
 from application.controllers.service_helper import service_request
-from application.exceptions import RasError
+from application.exceptions import RasError, ServiceUnavailableException
 from tests.test_client import TestClient
+
+SERVICE = "survey-service"
 
 
 class TestServiceHelper(TestClient):
     def test_service_request(self):
-        # Given a configured service
-        service = "case-service"
+        # Given an external service is configured to return a 200
         mock_response = Response()
         mock_response.status_code = 200
 
         # When a call is made to the service
         with patch("requests.get", return_value=mock_response):
-            response = service_request(service=service, endpoint="cases", search_value="test_case")
+            response = service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
 
             # Then it response successfully
             self.assertStatus(response, 200)
 
-    def test_service_request_failure(self):
+    def test_incorrect_service_request(self):
         # Given an incorrect Service key
         service = "INCORRECT SERVICE KEY"
         # When a call is made to the service
         # Then a RasError is raised
         with self.assertRaises(RasError):
-            service_request(service=service, endpoint="missing_end_point", search_value="value")
+            service_request(service=service, endpoint="missing_end_point", search_value="")
+
+    def test_service_request_http_error(self):
+        # Given an external service is configured to return a http error (404)
+        mock_response = Response()
+        mock_response.status_code = 404
+
+        # When a call is made to the service
+        # Then a RasError is raised
+        with patch("requests.get", return_value=mock_response):
+            with self.assertRaises(RasError) as exception:
+                service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
+
+        self.assertEquals(['survey-service returned a HTTPError'], exception.exception.errors)
+        self.assertEquals(500, exception.exception.status_code)
+
+    def test_service_request_connection_error(self):
+        # Given an external service is configured to return a connection error
+        # When a call is made to the service
+        # Then a ServiceUnavailableException is raised with a 503
+        with patch("requests.get", side_effect=requests.ConnectionError):
+            with self.assertRaises(ServiceUnavailableException) as exception:
+                service_request(service=SERVICE, endpoint="surveys", search_value="41320b22-b425-4fba-a90e-718898f718ce")
+
+        self.assertEquals(['survey-service returned a connection error'], exception.exception.errors)
+        self.assertEquals(503, exception.exception.status_code)
+
+    def test_service_request_timeout_error(self):
+        # Given an external service is configured to return a Timeout error
+        # When a call is made to the service
+        # Then a ServiceUnavailableException is raised with a 504
+        with patch("requests.get", side_effect=requests.Timeout):
+            with self.assertRaises(ServiceUnavailableException) as exception:
+                service_request(service=SERVICE, endpoint="surveys", search_value="test_case")
+        self.assertEquals(['survey-service has timed out'], exception.exception.errors)
+        self.assertEquals(504, exception.exception.status_code)

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -29,7 +29,7 @@ linked_exercise_id = "fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040"
 url_collection_instrument_link_url = "http://localhost:8145/collection-instrument/link"
 survey_url = "http://localhost:8080/surveys/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 survey_response_json = {"surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87", "surveyRef": "139", "surveyMode": "SEFT"}
-collection_exercise_url = "http://localhost:8145/collectionexercises/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+collection_exercise_url = "http://localhost:8145/collectionexercises/6790cdaa-28a9-4429-905c-0e943373b62e"
 
 survey_response_json_EQ_AND_SEFT = {
     "surveyId": "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87",
@@ -405,7 +405,7 @@ class TestCollectionInstrumentView(TestClient):
 
         # When a SEFT collection instrument is uploaded with a form_type already used by an eQ collection instrument
         response = self.client.post(
-            "/collection-instrument-api/1.0.2/upload/cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
+            "/collection-instrument-api/1.0.2/upload/6790cdaa-28a9-4429-905c-0e943373b62e"
             '?classifiers={"form_type": "001"}',
             headers=self.get_auth_headers(),
             data=data,
@@ -940,7 +940,7 @@ class TestCollectionInstrumentView(TestClient):
     @staticmethod
     @with_db_session
     def add_instrument_data(session=None, ci_type="SEFT"):
-        instrument = InstrumentModel(classifiers={"form_type": "001", "geography": "EN", "type": "EQ"}, ci_type=ci_type)
+        instrument = InstrumentModel(classifiers={"form_type": "001", "geography": "EN"}, ci_type=ci_type)
         if ci_type == "SEFT":
             seft_file = SEFTModel(instrument_id=instrument.instrument_id, file_name="test_file", length="999")
             instrument.seft_file = seft_file

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -388,7 +388,7 @@ class TestCollectionInstrumentView(TestClient):
         )
 
         # Then the file does not upload and an 400 error is returned
-        error = {"errors": ["This form type has already been used in this survey by SEFT"]}
+        error = {"errors": ["This form type is currently being used by SEFT for this survey"]}
         self.assertStatus(response, 400)
         self.assertEqual(response.json, error)
 
@@ -413,7 +413,7 @@ class TestCollectionInstrumentView(TestClient):
         )
 
         # Then the file does not upload and an 400 error is returned
-        error = {"errors": ["This form type has already been used in this survey by EQ"]}
+        error = {"errors": ["This form type is currently being used by EQ for this survey"]}
         self.assertStatus(response, 400)
         self.assertEqual(response.json, error)
 


### PR DESCRIPTION
# What and why?
This PR validates if a collection instrument can be uploaded according to it's form_type. 
# How to test?
Test with this PR deploy as well https://github.com/ONSdigital/response-operations-ui/pull/844
Using this PR create a EQ_AND_SEFT survey in rops, upload an eQ form_type (i.e 0001) then try to upload a SEFT using the same form type (a file named 064_201803_0001 would do it), it should return a warning. Repeat the process but the other way around Upload a SEFT first then an eQ. This is survey wide, so try across CE as well (i.e create a CE and upload a eQ, then in a different CE try to add a SEFT with the same form_type)
# Trello
