### PR TITLE
RAS-284 Delete collection instruments by ce id

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.14
+version: 3.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.14
+appVersion: 3.0.15
 

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -35,7 +35,7 @@ log = structlog.wrap_logger(logging.getLogger(__name__))
 COLLECTION_EXERCISE_NOT_FOUND_IN_DB = "Collection exercise not found in database"
 COLLECTION_EXERCISE_NOT_FOUND_ON_GCP = "Collection exercise not found on GCP"
 COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED = (
-    "Collection exercise and instruments successfully deleted from database and GCP(if applicable)"
+    "Collection exercise and instruments successfully deleted from database and GCP (if applicable)"
 )
 
 

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -408,9 +408,12 @@ class CollectionInstrument(object):
         session.delete(exercise)
 
         if exercise.seft_instrument_in_exercise:
+            survey_id = exercise.instruments[0].survey.survey_id
+            survey_ref = get_survey_details(survey_id).get("surveyRef")
+            prefix = f"{survey_ref}/{ce_id}"
             gcs_seft_bucket = GoogleCloudSEFTCIBucket(current_app.config)
             try:
-                gcs_seft_bucket.delete_files_by_prefix(ce_id)
+                gcs_seft_bucket.delete_files_by_prefix(prefix)
             except GCPBucketException:
                 return COLLECTION_EXERCISE_NOT_FOUND_ON_GCP, 404
 

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -20,7 +20,7 @@ from application.controllers.sql_queries import (
     query_instruments_form_type_with_different_survey_mode,
     query_survey_by_id,
 )
-from application.exceptions import RasError
+from application.exceptions import GCPBucketException, RasError
 from application.models.google_cloud_bucket import GoogleCloudSEFTCIBucket
 from application.models.models import (
     BusinessModel,
@@ -31,6 +31,12 @@ from application.models.models import (
 )
 
 log = structlog.wrap_logger(logging.getLogger(__name__))
+
+COLLECTION_EXERCISE_NOT_FOUND_IN_DB = "Collection exercise not found in database"
+COLLECTION_EXERCISE_NOT_FOUND_ON_GCP = "Collection exercise not found on GCP"
+COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED = (
+    "Collection exercise and instruments successfully deleted from database and GCP(if applicable)"
+)
 
 
 class CollectionInstrument(object):
@@ -299,7 +305,6 @@ class CollectionInstrument(object):
             self.update_collection_exercise_with_cis(instruments_to_remove, False, exercise_and_instruments, session)
 
     def update_collection_exercise_with_cis(self, instruments, to_add, exercise_and_instruments, session):
-
         for instrument_id in instruments:
             validate_uuid(instrument_id)
 
@@ -388,6 +393,28 @@ class CollectionInstrument(object):
             gcs_seft_bucket = GoogleCloudSEFTCIBucket(current_app.config)
             file_path = self._build_seft_file_path(instrument)
             gcs_seft_bucket.delete_file_from_bucket(file_path)
+
+    @with_db_session
+    def delete_collection_instruments_by_exercise(self, ce_id: str, session: Session = None):
+        """
+        Deletes all collection instruments associated with a collection exercise from the database and GCP
+        :param ce_id: A collection exercise id (UUID)
+        :param session: database session
+        """
+        exercise = self.get_exercise_by_id(ce_id, session)
+        if not exercise:
+            return COLLECTION_EXERCISE_NOT_FOUND_IN_DB, 404
+
+        session.delete(exercise)
+
+        if exercise.seft_instrument_in_exercise:
+            gcs_seft_bucket = GoogleCloudSEFTCIBucket(current_app.config)
+            try:
+                gcs_seft_bucket.delete_files_by_prefix(ce_id)
+            except GCPBucketException:
+                return COLLECTION_EXERCISE_NOT_FOUND_ON_GCP, 404
+
+        return COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED, 200
 
     @staticmethod
     def publish_remove_collection_instrument(exercise_id, instrument_id):

--- a/application/exceptions.py
+++ b/application/exceptions.py
@@ -9,6 +9,13 @@ class RasError(Exception):
         return {"errors": self.errors}
 
 
+class GCPBucketException(Exception):
+    def __init__(self, error, status_code):
+        super().__init__()
+        self.error = error
+        self.status_code = status_code
+
+
 class ServiceUnavailableException(RasError):
     pass
 

--- a/application/models/google_cloud_bucket.py
+++ b/application/models/google_cloud_bucket.py
@@ -6,7 +6,7 @@ from flask import current_app
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
 
-from application.exceptions import RasError
+from application.exceptions import GCPBucketException, RasError
 
 log = structlog.wrap_logger(logging.getLogger(__name__))
 
@@ -58,4 +58,11 @@ class GoogleCloudSEFTCIBucket:
             log.info("Successfully deleted SEFT CI file")
         except NotFound:
             log.error("SEFT CI file not found when attempting to delete")
+        return
+
+    def delete_files_by_prefix(self, prefix: str):
+        try:
+            self.bucket.delete_blobs(blobs=list(self.bucket.list_blobs(prefix=prefix)))
+        except NotFound:
+            raise GCPBucketException(f"No files were found with prefix {prefix} ", 404)
         return

--- a/application/models/google_cloud_bucket.py
+++ b/application/models/google_cloud_bucket.py
@@ -61,8 +61,13 @@ class GoogleCloudSEFTCIBucket:
         return
 
     def delete_files_by_prefix(self, prefix: str):
+        log.info(self.prefix)
+        log.info(list(self.bucket.list_blobs(prefix=prefix)))
+        log.info(list(self.bucket.list_blobs(prefix="babbal/062/f01ca355-0e66-4b71-86ce-ebe2829116d7")))
+
         try:
             self.bucket.delete_blobs(blobs=list(self.bucket.list_blobs(prefix=prefix)))
+
         except NotFound:
             raise GCPBucketException(f"No files were found with prefix {prefix} ", 404)
         return

--- a/application/models/google_cloud_bucket.py
+++ b/application/models/google_cloud_bucket.py
@@ -61,10 +61,7 @@ class GoogleCloudSEFTCIBucket:
         return
 
     def delete_files_by_prefix(self, prefix: str):
-        log.info(self.prefix)
-        log.info(list(self.bucket.list_blobs(prefix=prefix)))
-        log.info(list(self.bucket.list_blobs(prefix="babbal/062/f01ca355-0e66-4b71-86ce-ebe2829116d7")))
-
+        prefix = f"{self.prefix}/{prefix}" if self.prefix else prefix
         try:
             self.bucket.delete_blobs(blobs=list(self.bucket.list_blobs(prefix=prefix)))
 

--- a/application/models/google_cloud_bucket.py
+++ b/application/models/google_cloud_bucket.py
@@ -64,7 +64,6 @@ class GoogleCloudSEFTCIBucket:
         prefix = f"{self.prefix}/{prefix}" if self.prefix else prefix
         try:
             self.bucket.delete_blobs(blobs=list(self.bucket.list_blobs(prefix=prefix)))
-
         except NotFound:
             raise GCPBucketException(f"No files were found with prefix {prefix} ", 404)
         return

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -126,7 +126,11 @@ class ExerciseModel(Base):
 
     id = Column(Integer, primary_key=True)
     exercise_id = Column(UUID, index=True)
-    instruments = relationship("InstrumentModel", secondary=instrument_exercise_table, back_populates="exercises")
+    instruments = relationship(
+        "InstrumentModel",
+        secondary=instrument_exercise_table,
+        back_populates="exercises",
+    )
 
     def __init__(self, exercise_id=None):
         """Initialise the class with optionally supplied defaults"""
@@ -143,6 +147,10 @@ class ExerciseModel(Base):
     @property
     def instrument_ids(self):
         return [instrument.id for instrument in self.instruments]
+
+    @property
+    def seft_instrument_in_exercise(self):
+        return any(instrument.type == "SEFT" for instrument in self.instruments)
 
 
 class SurveyModel(Base):

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -94,6 +94,12 @@ def delete_seft_collection_instrument(instrument_id):
     return make_response(COLLECTION_INSTRUMENT_DELETED_SUCCESSFUL, 200)
 
 
+@collection_instrument_view.route("/delete/collection-exercise/<exercise_id>", methods=["DELETE"])
+def delete_collection_instruments_by_exercise_id(exercise_id):
+    message, status = CollectionInstrument().delete_collection_instruments_by_exercise(exercise_id)
+    return make_response(message, status)
+
+
 @collection_instrument_view.route("/download_csv/<exercise_id>", methods=["GET"])
 def download_csv(exercise_id):
     csv = CollectionInstrument().get_instruments_by_exercise_id_csv(exercise_id)

--- a/tests/controllers/test_collection_instrument.py
+++ b/tests/controllers/test_collection_instrument.py
@@ -185,26 +185,26 @@ class TestCollectionInstrument(TestClient):
         mock_storage.Client().bucket().delete_blobs.assert_not_called()
         self.assertEqual(status, 200)
 
-    def test_delete_collection_instruments_by_exercise_not_found_db(
-        self,
-    ):
+    def test_delete_collection_instruments_by_exercise_not_found_db(self):
         # Given a collection exercise that doesn't exist in the db
         incorrect_ce_id = "228f41a1-8e65-4327-b579-6c531c7f97a3"
 
         # When delete_collection_instruments_by_exercise is called with the relevant collection exercise id
         message, status = self.collection_instrument.delete_collection_instruments_by_exercise(incorrect_ce_id)
 
-        # Then a 404 is returned
+        # Then a 404 is returned with the correct message
         self.assertEqual(message, COLLECTION_EXERCISE_NOT_FOUND_IN_DB)
         self.assertEqual(status, 404)
 
     @patch("application.models.google_cloud_bucket.storage")
     def test_delete_collection_instruments_by_exercise_not_found_gcp(self, mock_storage):
-        # Given a collection exercise id that doesn't exist in the db
+        # Given a collection exercise id that doesn't exist on GCP
         mock_storage.Client().bucket().delete_blobs.side_effect = NotFound("testing")
 
-        self._add_instrument_data()
+        # When delete_collection_instruments_by_exercise is called with the relevant collection exercise id
         message, status = self.collection_instrument.delete_collection_instruments_by_exercise(COLLECTION_EXERCISE_ID)
+
+        # Then a 404 is returned with the correct message
         self.assertEqual(message, COLLECTION_EXERCISE_NOT_FOUND_ON_GCP)
         self.assertEqual(status, 404)
 

--- a/tests/controllers/test_collection_instrument.py
+++ b/tests/controllers/test_collection_instrument.py
@@ -158,9 +158,9 @@ class TestCollectionInstrument(TestClient):
     @patch("application.models.google_cloud_bucket.storage")
     @requests_mock.mock()
     def test_delete_collection_instruments_by_exercise_seft(self, mock_storage, mock_request):
-        self._mock_survey_service_request(mock_request)
         # Given a SEFT instrument and exercise are added at setup
         # When delete_collection_instruments_by_exercise is called with the relevant collection exercise id
+        self._mock_survey_service_request(mock_request)
         message, status = self.collection_instrument.delete_collection_instruments_by_exercise(COLLECTION_EXERCISE_ID)
 
         # Then the exercise is deleted in the DB and on GCP
@@ -172,8 +172,8 @@ class TestCollectionInstrument(TestClient):
     @patch("application.models.google_cloud_bucket.storage")
     @requests_mock.mock()
     def test_delete_collection_instruments_by_exercise_eq_and_seft(self, mock_storage, mock_request):
-        self._mock_survey_service_request(mock_request)
         # Given a SEFT instrument and exercise are added at setup, and an EQ instrument added to the exercise
+        self._mock_survey_service_request(mock_request)
         self._add_instrument_to_exercise(ci_type="EQ", exercise_id=COLLECTION_EXERCISE_ID)
 
         # When delete_collection_instruments_by_exercise is called with the relevant collection exercise id
@@ -215,8 +215,8 @@ class TestCollectionInstrument(TestClient):
     @patch("application.models.google_cloud_bucket.storage")
     @requests_mock.mock()
     def test_delete_collection_instruments_by_exercise_not_found_gcp(self, mock_storage, mock_request):
-        self._mock_survey_service_request(mock_request)
         # Given a collection exercise id that doesn't exist on GCP
+        self._mock_survey_service_request(mock_request)
         mock_storage.Client().bucket().delete_blobs.side_effect = NotFound("testing")
 
         # When delete_collection_instruments_by_exercise is called with the relevant collection exercise id

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -8,6 +8,9 @@ from flask import current_app
 from requests.models import Response
 from six import BytesIO
 
+from application.controllers.collection_instrument import (
+    COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED,
+)
 from application.controllers.session_decorator import with_db_session
 from application.exceptions import RasError
 from application.models.models import (
@@ -461,6 +464,24 @@ class TestCollectionInstrumentView(TestClient):
         # Then the instrument is deleted successfully
         self.assertStatus(response, 200)
         self.assertEqual(response.data.decode(), COLLECTION_INSTRUMENT_DELETED_SUCCESSFUL)
+
+    @mock.patch(
+        "application.controllers.collection_instrument.CollectionInstrument.delete_collection_instruments_by_exercise"
+    )
+    def test_delete_collection_instrument_by_exercise(self, delete_collection_instruments_by_exercise):
+        # Given delete_collection_instruments_by_exercise is mocked to return a successful deletion
+        delete_collection_instruments_by_exercise.return_value = COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED, 200
+
+        # When delete_collection_instruments_by_exercise is called
+        response = self.client.delete(
+            "/collection-instrument-api/1.0.2/delete/collection-exercise/fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040",
+            headers=self.get_auth_headers(),
+            content_type="multipart/form-data",
+        )
+
+        # Then the response is as expected
+        self.assertStatus(response, 200)
+        self.assertEqual(response.data.decode(), COLLECTION_EXERCISE_AND_ASSOCIATED_FILES_DELETED)
 
     def test_delete_eq_collection_instrument(self):
         eq_collection_instrument_id = self.add_instrument_data(ci_type="EQ")


### PR DESCRIPTION
# What and why?
This PR adds an end point to delete the collection exercise and associated collection instruments on GCP

N.B 

1. As discussed in tech because of the many to many relationship between exercise and collection instruments and the state of data in PROD I can't add a cascade to exercise to remove all CIs' associated with it. This will not stop CIs' being deleted from GCP, but it will leave CI orphans in the db. This is being tackled when the CI registry is introduced when CE will be a one to many relationship

2. I have been a lot more robust with tests and error catching then how the current repo is written, however stopped short of tackling the issues with  _with_db_session_  Realistically we should have error catching and tests on all these session updates but the decorator needs a fair amount of work

3. This is only for the collection instrument services, so you will still see the CE in rops if you refresh after you call the end point

# How to test?
Deploy this PR to GCP (it is a right pain to test locally as you need to hook up the GCS bucket so far easier to deploy to GCP) and create a SEFT CE in rops and add some instruments, check they are in the bucket (ras-rm-seft-ci-dev) Look in your db and grab the CE id and then use it to hit the endpoint
```
http://localhost:8002/collection-instrument-api/1.0.2/delete/collection-exercise/<your ce id>
``` 
Use something like postman as you will need the method to be DELETE, also you will need to add in Basic auth on the request for dev its admin/secret

It's going to look a bit like this 
![image](https://user-images.githubusercontent.com/14179817/232056900-efd2a89f-ea75-4a05-b884-328676554b7b.png)


Now check that the folder and CIs are removed on GCP and that the exercise is removed from the CI DB


# Trello
