### PR TITLE
RAS-728 Fix issue with ready for live button

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.17
+version: 3.0.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.17
+appVersion: 3.0.18
 

--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -274,7 +274,7 @@ class CollectionInstrument(object):
     @with_db_session
     def update_exercise_eq_instruments(self, exercise_id: str, instruments: list, session=None) -> bool:
         """
-        Updates eQ instruments used by an exercise. Current instruments are used to determine which ones should be
+        Updates eQ instruments for an exercise. Current instruments are used to determine which ones should be
         appended and/or removed.
         :param exercise_id: The collection exercise id
         :param instruments: A list of instruments that the collection exercise should now have

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -54,21 +54,21 @@ def service_request(service, endpoint, search_value):
     return response
 
 
-def collection_exercise_instrument_update_request(exercise_id: str) -> object:
+def collection_exercise_instrument_update_request(action, exercise_id: str) -> object:
     """
     Posts a request to the collection exercise service to notify of a collection instrument change
     :param: json_message
     :type: json
     :return: response
     """
-
     auth = (current_app.config.get("SECURITY_USER_NAME"), current_app.config.get("SECURITY_USER_PASSWORD"))
+    json_message = {"action": action, "exercise_id": str(exercise_id)}
 
     try:
         collection_exercise_url = current_app.config["COLLECTION_EXERCISE_URL"]
         url = f"{collection_exercise_url}/collection-instrument/link"
-        log.info("Making request to collection exercise to acknowledge instruments have changed")
-        response = requests.post(url, json={"exercise_id": str(exercise_id)}, auth=auth)
+        log.info("Making request to collection exercise to acknowledge instruments have been changed", action=action)
+        response = requests.post(url, json=json_message, auth=auth)
         response.raise_for_status()
     except KeyError:
         raise RasError("collection exercise service not configured", 500)

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -54,9 +54,9 @@ def service_request(service, endpoint, search_value):
     return response
 
 
-def collection_instrument_link(exercise_id):
+def collection_exercise_instrument_update_request(exercise_id: str) -> object:
     """
-    Posts a message to the collection exercise to notify of a collection instrument change
+    Posts a request to the collection exercise service to notify of a collection instrument change
     :param: json_message
     :type: json
     :return: response
@@ -68,7 +68,7 @@ def collection_instrument_link(exercise_id):
         collection_exercise_url = current_app.config["COLLECTION_EXERCISE_URL"]
         url = f"{collection_exercise_url}/collection-instrument/link"
         log.info("Making request to collection exercise to acknowledge instruments have changed")
-        response = requests.post(url, json={"exercise_id": str(exercise_id), "instrument_id": str(exercise_id)}, auth=auth)
+        response = requests.post(url, json={"exercise_id": str(exercise_id)}, auth=auth)
         response.raise_for_status()
     except KeyError:
         raise RasError("collection exercise service not configured", 500)

--- a/application/controllers/service_helper.py
+++ b/application/controllers/service_helper.py
@@ -54,9 +54,9 @@ def service_request(service, endpoint, search_value):
     return response
 
 
-def collection_instrument_link(json_message):
+def collection_instrument_link(exercise_id):
     """
-    Makes a post request to collection exercise service acknowledging collection instrument load
+    Posts a message to the collection exercise to notify of a collection instrument change
     :param: json_message
     :type: json
     :return: response
@@ -67,8 +67,8 @@ def collection_instrument_link(json_message):
     try:
         collection_exercise_url = current_app.config["COLLECTION_EXERCISE_URL"]
         url = f"{collection_exercise_url}/collection-instrument/link"
-        log.info("Making request to collection exercise to acknowledge instrument load")
-        response = requests.post(url, json=json_message, auth=auth)
+        log.info("Making request to collection exercise to acknowledge instruments have changed")
+        response = requests.post(url, json={"exercise_id": str(exercise_id), "instrument_id": str(exercise_id)}, auth=auth)
         response.raise_for_status()
     except KeyError:
         raise RasError("collection exercise service not configured", 500)

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -146,6 +146,8 @@ class ExerciseModel(Base):
 
     @property
     def instrument_ids(self):
+        print("ppeawfpapfpafpawepfpawefpawfpawpfwpefpawfpwpfapwfpwef")
+        print(self.instruments)
         return [instrument.id for instrument in self.instruments]
 
     @property

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -146,8 +146,6 @@ class ExerciseModel(Base):
 
     @property
     def instrument_ids(self):
-        print("ppeawfpapfpafpawepfpawefpawfpawpfwpefpawfpwpfapwfpwef")
-        print(self.instruments)
         return [instrument.id for instrument in self.instruments]
 
     @property

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -37,7 +37,7 @@ def upload_seft_collection_instrument(exercise_id, ru_ref=None):
     classifiers = request.args.get("classifiers")
     instrument = CollectionInstrument().upload_seft_to_bucket(exercise_id, file, ru_ref=ru_ref, classifiers=classifiers)
 
-    if not collection_exercise_instrument_update_request(exercise_id):
+    if not collection_exercise_instrument_update_request("ADD", exercise_id):
         log.error(
             "Failed to publish upload message",
             instrument_id=instrument.instrument_id,
@@ -73,7 +73,7 @@ def update_exercise_eq_instruments_(exercise_id):
     instruments_updated = CollectionInstrument().update_exercise_eq_instruments(exercise_id, instruments)
 
     if instruments_updated:
-        collection_exercise_instrument_update_request(exercise_id)
+        collection_exercise_instrument_update_request("UPDATE", exercise_id)
 
     return make_response(COLLECTION_EXERCISE_CI_UPDATE_SUCCESSFUL, 200)
 
@@ -81,7 +81,7 @@ def update_exercise_eq_instruments_(exercise_id):
 @collection_instrument_view.route("/link-exercise/<instrument_id>/<exercise_id>", methods=["POST"])
 def link_collection_instrument(instrument_id, exercise_id):
     CollectionInstrument().link_instrument_to_exercise(instrument_id, exercise_id)
-    response = collection_exercise_instrument_update_request(exercise_id)
+    response = collection_exercise_instrument_update_request("ADD", exercise_id)
     if response.status_code != 200:
         log.error("Failed to publish upload message", instrument_id=instrument_id, collection_exercise_id=exercise_id)
         raise RasError("Failed to publish upload message", 500)
@@ -92,7 +92,7 @@ def link_collection_instrument(instrument_id, exercise_id):
 def unlink_collection_instrument(instrument_id, exercise_id):
     unlink_instrument = CollectionInstrument().unlink_instrument_from_exercise(instrument_id, exercise_id)
     if unlink_instrument:
-        collection_exercise_instrument_update_request(exercise_id)
+        collection_exercise_instrument_update_request("REMOVE", exercise_id)
     return make_response(UNLINK_SUCCESSFUL, 200)
 
 

--- a/application/views/collection_instrument_view.py
+++ b/application/views/collection_instrument_view.py
@@ -35,7 +35,7 @@ def upload_seft_collection_instrument(exercise_id, ru_ref=None):
     classifiers = request.args.get("classifiers")
     instrument = CollectionInstrument().upload_seft_to_bucket(exercise_id, file, ru_ref=ru_ref, classifiers=classifiers)
 
-    if not publish_uploaded_collection_instrument(exercise_id, instrument.instrument_id):
+    if not collection_instrument_link(exercise_id):
         log.error(
             "Failed to publish upload message",
             instrument_id=instrument.instrument_id,
@@ -65,17 +65,22 @@ def upload_eq_collection_instrument():
     return make_response(UPLOAD_SUCCESSFUL, 200)
 
 
-@collection_instrument_view.route("/update_collection_exercise_instruments/<exercise_id>", methods=["POST"])
-def update_collection_exercise_instruments(exercise_id):
+@collection_instrument_view.route("/update-eq-instruments/<exercise_id>", methods=["POST"])
+def update_exercise_eq_instruments_(exercise_id):
     instruments = request.args.getlist("instruments")
-    CollectionInstrument().update_collection_exercise_instruments(instruments, exercise_id)
+    collection_instrument = CollectionInstrument()
+    instruments_updated = collection_instrument.update_exercise_eq_instruments(exercise_id, instruments)
+
+    if instruments_updated:
+        collection_instrument_link(exercise_id)
+
     return make_response(COLLECTION_EXERCISE_CI_UPDATE_SUCCESSFUL, 200)
 
 
 @collection_instrument_view.route("/link-exercise/<instrument_id>/<exercise_id>", methods=["POST"])
 def link_collection_instrument(instrument_id, exercise_id):
     CollectionInstrument().link_instrument_to_exercise(instrument_id, exercise_id)
-    response = publish_uploaded_collection_instrument(exercise_id, instrument_id)
+    response = collection_instrument_link(exercise_id)
     if response.status_code != 200:
         log.error("Failed to publish upload message", instrument_id=instrument_id, collection_exercise_id=exercise_id)
         raise RasError("Failed to publish upload message", 500)
@@ -84,7 +89,10 @@ def link_collection_instrument(instrument_id, exercise_id):
 
 @collection_instrument_view.route("/unlink-exercise/<instrument_id>/<exercise_id>", methods=["PUT"])
 def unlink_collection_instrument(instrument_id, exercise_id):
-    CollectionInstrument().unlink_instrument_from_exercise(instrument_id, exercise_id)
+    collection_instrument = CollectionInstrument()
+    unlink_instrument = collection_instrument.unlink_instrument_from_exercise(instrument_id, exercise_id)
+    if unlink_instrument:
+        collection_instrument_link(exercise_id)
     return make_response(UNLINK_SUCCESSFUL, 200)
 
 
@@ -155,15 +163,3 @@ def instrument_data(instrument_id):
         response = make_response(COLLECTION_INSTRUMENT_NOT_FOUND, 404)
 
     return response
-
-
-def publish_uploaded_collection_instrument(exercise_id, instrument_id):
-    """
-    Publish message to collection instrument link
-    :param exercise_id: An exercise id (UUID)
-    :param instrument_id: The id (UUID) for the newly created collection instrument
-    :return True if message successfully linked
-    """
-    log.info("Publishing upload message", exercise_id=exercise_id, instrument_id=instrument_id)
-    json_message = {"action": "ADD", "exercise_id": str(exercise_id), "instrument_id": str(instrument_id)}
-    return collection_instrument_link(json_message)

--- a/tests/controllers/test_collection_instrument.py
+++ b/tests/controllers/test_collection_instrument.py
@@ -20,14 +20,10 @@ from application.models.models import (
     SEFTModel,
     SurveyModel,
 )
-from application.views.collection_instrument_view import (
-    publish_uploaded_collection_instrument,
-)
 from tests.test_client import TestClient
 
 TEST_FILE_LOCATION = "tests/files/test.xlsx"
 COLLECTION_EXERCISE_ID = "db0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
-url_collection_instrument_link_url = "http://localhost:8145/collection-instrument/link"
 
 
 class TestCollectionInstrumentUnit(TestCase):
@@ -226,19 +222,6 @@ class TestCollectionInstrument(TestClient):
         self.assertEqual(message, COLLECTION_EXERCISE_NOT_FOUND_ON_GCP)
         self.assertEqual(status, 404)
 
-    def test_unlink_instrument_from_exercise_seft(self):
-        eq_collection_instrument = self._add_instrument_data()
-        with self.assertRaises(RasError) as error:
-            self.collection_instrument.unlink_instrument_from_exercise(
-                str(eq_collection_instrument), COLLECTION_EXERCISE_ID
-            )
-
-        self.assertEqual(405, error.exception.status_code)
-        self.assertEqual(
-            [f"{eq_collection_instrument} is of type SEFT which should be deleted and not unlinked"],
-            error.exception.errors,
-        )
-
     def test_get_instrument_by_incorrect_id(self):
         # Given there is an instrument in the db
         # When an incorrect instrument id is used to find that instrument
@@ -246,22 +229,6 @@ class TestCollectionInstrument(TestClient):
 
         # Then that instrument is not found
         self.assertEqual(instrument, None)
-
-    @requests_mock.mock()
-    def test_publish_uploaded_collection_instrument(self, mock_request):
-        mock_request.post(url_collection_instrument_link_url, status_code=200)
-        # Given there is an instrument in the db
-        result = publish_uploaded_collection_instrument(COLLECTION_EXERCISE_ID, self.instrument_id)
-
-        # Then the message is successfully published
-        self.assertEqual(result.status_code, 200)
-
-    @requests_mock.mock()
-    def test_publish_uploaded_collection_instrument_fails(self, mock_request):
-        mock_request.post(url_collection_instrument_link_url, status_code=500)
-        # Given there is an instrument in the db
-        with self.assertRaises(Exception):
-            publish_uploaded_collection_instrument(COLLECTION_EXERCISE_ID, self.instrument_id)
 
     @with_db_session
     def _add_instrument_data(self, session=None, ci_type="SEFT", exercise_id=COLLECTION_EXERCISE_ID):

--- a/tests/controllers/test_service_helper.py
+++ b/tests/controllers/test_service_helper.py
@@ -1,13 +1,20 @@
 from unittest.mock import patch
 
 import requests
+import requests_mock
 from requests.models import Response
 
-from application.controllers.service_helper import service_request
+from application.controllers.service_helper import (
+    collection_instrument_link,
+    service_request,
+)
 from application.exceptions import RasError, ServiceUnavailableException
 from tests.test_client import TestClient
 
 SERVICE = "survey-service"
+
+url_collection_instrument_link_url = "http://localhost:8145/collection-instrument/link"
+COLLECTION_EXERCISE_ID = "db0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 
 
 class TestServiceHelper(TestClient):
@@ -71,3 +78,21 @@ class TestServiceHelper(TestClient):
                 service_request(service=SERVICE, endpoint="surveys", search_value="test_case")
         self.assertEqual(["survey-service has timed out"], exception.exception.errors)
         self.assertEqual(504, exception.exception.status_code)
+
+    @requests_mock.mock()
+    def test_publish_uploaded_collection_instrument(self, mock_request):
+        # Given a 200 response from the collection exercise service is mocked
+        mock_request.post(url_collection_instrument_link_url, status_code=200)
+        # When a message is posted to that service
+        result = collection_instrument_link(COLLECTION_EXERCISE_ID)
+        # Then the service responds correctly
+        self.assertEqual(result.status_code, 200)
+
+    @requests_mock.mock()
+    def test_publish_uploaded_collection_instrument_fails(self, mock_request):
+        # Given a 500 response from the collection exercise service is mocked
+        mock_request.post(url_collection_instrument_link_url, status_code=500)
+        # When a message is posted to that service
+        # Then a RasError is raised
+        with self.assertRaises(RasError):
+            collection_instrument_link(COLLECTION_EXERCISE_ID)

--- a/tests/controllers/test_service_helper.py
+++ b/tests/controllers/test_service_helper.py
@@ -83,7 +83,7 @@ class TestServiceHelper(TestClient):
         # Given a 200 response from the collection exercise service is mocked
         mock_request.post(COLLECTION_EXERCISE_LINK_URL, status_code=200)
         # When a message is posted to that service
-        result = collection_exercise_instrument_update_request(COLLECTION_EXERCISE_ID)
+        result = collection_exercise_instrument_update_request("ADD", COLLECTION_EXERCISE_ID)
         # Then the service responds correctly
         self.assertEqual(result.status_code, 200)
 
@@ -94,4 +94,4 @@ class TestServiceHelper(TestClient):
         # When a message is posted to that service
         # Then a RasError is raised
         with self.assertRaises(RasError):
-            collection_exercise_instrument_update_request(COLLECTION_EXERCISE_ID)
+            collection_exercise_instrument_update_request("ADD", COLLECTION_EXERCISE_ID)

--- a/tests/controllers/test_service_helper.py
+++ b/tests/controllers/test_service_helper.py
@@ -5,15 +5,14 @@ import requests_mock
 from requests.models import Response
 
 from application.controllers.service_helper import (
-    collection_instrument_link,
+    collection_exercise_instrument_update_request,
     service_request,
 )
 from application.exceptions import RasError, ServiceUnavailableException
 from tests.test_client import TestClient
 
 SERVICE = "survey-service"
-
-url_collection_instrument_link_url = "http://localhost:8145/collection-instrument/link"
+COLLECTION_EXERCISE_LINK_URL = "http://localhost:8145/collection-instrument/link"
 COLLECTION_EXERCISE_ID = "db0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
 
 
@@ -82,17 +81,17 @@ class TestServiceHelper(TestClient):
     @requests_mock.mock()
     def test_publish_uploaded_collection_instrument(self, mock_request):
         # Given a 200 response from the collection exercise service is mocked
-        mock_request.post(url_collection_instrument_link_url, status_code=200)
+        mock_request.post(COLLECTION_EXERCISE_LINK_URL, status_code=200)
         # When a message is posted to that service
-        result = collection_instrument_link(COLLECTION_EXERCISE_ID)
+        result = collection_exercise_instrument_update_request(COLLECTION_EXERCISE_ID)
         # Then the service responds correctly
         self.assertEqual(result.status_code, 200)
 
     @requests_mock.mock()
     def test_publish_uploaded_collection_instrument_fails(self, mock_request):
         # Given a 500 response from the collection exercise service is mocked
-        mock_request.post(url_collection_instrument_link_url, status_code=500)
+        mock_request.post(COLLECTION_EXERCISE_LINK_URL, status_code=500)
         # When a message is posted to that service
         # Then a RasError is raised
         with self.assertRaises(RasError):
-            collection_instrument_link(COLLECTION_EXERCISE_ID)
+            collection_exercise_instrument_update_request(COLLECTION_EXERCISE_ID)

--- a/tests/views/test_collection_instrument_view.py
+++ b/tests/views/test_collection_instrument_view.py
@@ -929,14 +929,14 @@ class TestCollectionInstrumentView(TestClient):
         self.assertEqual(response_data["errors"][0], "Unable to find instrument or exercise")
 
     @requests_mock.mock()
-    def test_add_update_collection_exercise_instruments(self, mock_request):
+    def test_update_eq_instruments(self, mock_request):
         # Given an instrument which is in the db is not linked to a collection exercise
         mock_request.post(url_collection_instrument_link_url, status_code=200)
         instrument_id = self.add_instrument_without_exercise()
         exercise_id = "c3c0403a-6e9c-46f6-af5e-5f67fefb2a9d"
         # When the instrument is linked to an exercise
         response = self.client.post(
-            f"/collection-instrument-api/1.0.2/update_collection_exercise_instruments/{exercise_id}?"
+            f"/collection-instrument-api/1.0.2/update-eq-instruments/{exercise_id}?"
             f"instruments={str(instrument_id)}",
             headers=self.get_auth_headers(),
         )
@@ -957,7 +957,7 @@ class TestCollectionInstrumentView(TestClient):
         exercise_id = "c3c0403a-6e9c-46f6-af5e-5f67fefb2a9d"
 
         response = self.client.post(
-            f"/collection-instrument-api/1.0.2/update_collection_exercise_instruments/{exercise_id}?"
+            f"/collection-instrument-api/1.0.2/update-eq-instruments/{exercise_id}?"
             f"instruments={str(instrument_id)}",
             headers=self.get_auth_headers(),
         )
@@ -975,7 +975,7 @@ class TestCollectionInstrumentView(TestClient):
         exercise_id = "c3c0403a-6e9c-46f6-af5e-5f67fefb2a9d"
         # And the instrument is linked to an exercise
         self.client.post(
-            f"/collection-instrument-api/1.0.2/update_collection_exercise_instruments/{exercise_id}?"
+            f"/collection-instrument-api/1.0.2/update-eq-instruments/{exercise_id}?"
             f"instruments={str(instrument_id)}",
             headers=self.get_auth_headers(),
         )
@@ -984,7 +984,7 @@ class TestCollectionInstrumentView(TestClient):
 
         # When the instrument is unlinked to an exercise
         response = self.client.post(
-            f"/collection-instrument-api/1.0.2/update_collection_exercise_instruments/{exercise_id}",
+            f"/collection-instrument-api/1.0.2/update-eq-instruments/{exercise_id}",
             headers=self.get_auth_headers(),
         )
 


### PR DESCRIPTION
# What and why?
This PR fixes the bug associated with the ready for live button not appearing after initially adding a collection instrument. I have also done some refactoring and tidying of the code connected to the problem
# How to test?
Deploy all 3 PRs, this one,  https://github.com/ONSdigital/rm-collection-exercise-service/pull/312 and https://github.com/ONSdigital/rm-collection-exercise-service/pull/312 Now on rops create an eq CE (SEFT will work for add as well, see below for bug on remove) and enter all details bar the CI. Now enter the CI and attach that CI, notice when you hit done the ready for live button appears. Go back in and remove the CI, notice it is gone

N.B there are 2 bugs
1. with EQ_AND_SEFT the current eQ adding code will remove SEFT instruments as well, a card has been create for this
2. Remove a seft instrument is not configured correctly, it currently is not calling CE, so if you add a CI and then remove that ready for live is still present. Once again this is out of scope and another card is needed
# Trello
