### PR TITLE
RAS-815: EQ_AND_SEFT when adding a eQ instruments SEFT ones will be removed

### DIFF
--- a/application/controllers/collection_instrument.py
+++ b/application/controllers/collection_instrument.py
@@ -284,7 +284,8 @@ class CollectionInstrument(object):
 
         validate_uuid(exercise_id)
         exercise = self._find_or_create_exercise(exercise_id, session)
-        current_instruments = [str(instrument.instrument_id) for instrument in exercise.instruments]
+        current_instruments = [str(instrument.instrument_id) for instrument in exercise.instruments
+                               if instrument.type == 'EQ']
 
         instruments_to_add = set(instruments).difference(current_instruments)
         instruments_to_remove = set(current_instruments).difference(instruments)

--- a/config.py
+++ b/config.py
@@ -12,12 +12,16 @@ class Config(object):
     SECURITY_USER_NAME = os.getenv("SECURITY_USER_NAME", "admin")
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD", "secret")
     MAX_UPLOAD_FILE_NAME_LENGTH = os.getenv("MAX_UPLOAD_FILE_NAME_LENGTH", 50)
-    DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:6432/postgres")
+    DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres")
     DATABASE_SCHEMA = os.getenv("DATABASE_SCHEMA", "ras_ci")
 
-    SEFT_DOWNLOAD_BUCKET_NAME = os.getenv("SEFT_DOWNLOAD_BUCKET_NAME")
-    GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
-    SEFT_DOWNLOAD_BUCKET_FILE_PREFIX = os.getenv("SEFT_DOWNLOAD_BUCKET_FILE_PREFIX")
+    SEFT_DOWNLOAD_BUCKET_NAME = "ras-rm-seft-ci-dev"
+    GOOGLE_CLOUD_PROJECT = "ras-rm-dev"
+    SEFT_DOWNLOAD_BUCKET_FILE_PREFIX = "scorfs"
+    #
+    # SEFT_DOWNLOAD_BUCKET_NAME = os.getenv("SEFT_DOWNLOAD_BUCKET_NAME")
+    # GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+    # SEFT_DOWNLOAD_BUCKET_FILE_PREFIX = os.getenv("SEFT_DOWNLOAD_BUCKET_FILE_PREFIX")
 
     UPLOAD_FILE_EXTENSIONS = "xls,xlsx"
 
@@ -38,9 +42,9 @@ class TestingConfig(Config):
     LOGGING_LEVEL = "ERROR"
     SECURITY_USER_NAME = "admin"
     SECURITY_USER_PASSWORD = "secret"
-    DATABASE_URI = os.getenv("TEST_DATABASE_URI", "postgresql://postgres:postgres@localhost:6432/postgres")
+    DATABASE_URI = os.getenv("TEST_DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres")
     DATABASE_SCHEMA = "ras_ci"
     ONS_CRYPTOKEY = "somethingsecure"
-    SEFT_DOWNLOAD_BUCKET_NAME = "TEST_BUCKET"
-    GOOGLE_CLOUD_PROJECT = "TEST_PROJECT"
-    SEFT_DOWNLOAD_BUCKET_FILE_PREFIX = ""
+    SEFT_DOWNLOAD_BUCKET_NAME = "ras-rm-seft-ci-dev"
+    GOOGLE_CLOUD_PROJECT = "ras-rm-dev"
+    SEFT_DOWNLOAD_BUCKET_FILE_PREFIX = "scorfs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres
     ports:
-      - "6432:5432"
+      - "5432:5432"
 
   ras-collection-instrument:
     container_name: ras-collection-instrument


### PR DESCRIPTION
What and why?
It has been found that when a user adds a SEFT CI first and then an eQ CI for a CE for a survey with a eq SEFT type, the SEFT will be removed and the user has to go back to re-add it before moving forward.

This fix will grab the CI when the eQ is added/removed and ensure that it is not removed when the eQ CI is updated.

How to test?
Create a joint EQ SEFT survey (if one does not already exist)
Create a CE for that survey
Upload a SEFT CCI first
The add an eQ CI
When clicking 'Done' on the eq CI page, you will be returned to the CE overview page and the totals for the SEFT CI should remain unchanged
Click on the 'View or Upload' for the SEFT CI and the uploaded SEFTs should still be there.
As usual run the unit and acceptance tests.

#Jira
https://jira.ons.gov.uk/browse/RAS-815
