### PR TITLE
Introduce registry-instrument resource

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,9 +14,9 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.44
+version: 3.0.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.44
+appVersion: 3.0.45
 

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -15,7 +15,7 @@ log = structlog.wrap_logger(logging.getLogger(__name__))
 
 class RegistryInstrument(object):
     @with_db_session
-    def get_registry_instruments_by_exercise_id(self, exercise_id, session=None):
+    def get_by_exercise_id(self, exercise_id, session=None):
         """
         Retrieves a list of selected CIR instruments for the given collection exercise
 
@@ -33,7 +33,7 @@ class RegistryInstrument(object):
         return response
 
     @with_db_session
-    def get_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
+    def get_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
         """
         Retrieves the selected CIR instrument for the given collection exercise and form type
 
@@ -53,7 +53,7 @@ class RegistryInstrument(object):
         return None
 
     @with_db_session
-    def save_registry_instrument_for_exercise_id_and_formtype(
+    def save_for_exercise_id_and_formtype(
         self, survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session=None
     ):
         """
@@ -65,7 +65,7 @@ class RegistryInstrument(object):
         :return: True if successful, and is_new indicating if a new object was created
         """
 
-        registry_instrument, is_new = self._find_or_create_registry_instrument(
+        registry_instrument, is_new = self._find_or_create(
             survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
         )
 
@@ -73,7 +73,7 @@ class RegistryInstrument(object):
         return True, is_new
 
     @with_db_session
-    def delete_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
+    def delete_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
         """
         Delete the selected CIR instrument for the given collection exercise and form type
 
@@ -95,9 +95,7 @@ class RegistryInstrument(object):
             return False
 
     @staticmethod
-    def _find_or_create_registry_instrument(
-        survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
-    ):
+    def _find_or_create(survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session):
         """
         Retrieves an existing selected RegistryInstrumentModel object from the db if it exists,
         or creates a new RegistryInstrumentModel object if it doesn't exist

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -111,7 +111,13 @@ class RegistryInstrument(object):
             exercise_id, form_type, session
         ).first()
 
-        if not registry_instrument:
+        if registry_instrument:
+            log.info("Registry instrument found, updating", exercise_id=exercise_id, form_type=form_type)
+            registry_instrument.ci_version = ci_version
+            registry_instrument.guid = guid
+            registry_instrument.published_at = published_at
+            return registry_instrument, False
+        else:
             log.info("Registry instrument NOT found, creating", exercise_id=exercise_id, form_type=form_type)
             registry_instrument = RegistryInstrumentModel()
             registry_instrument.survey_id = survey_id
@@ -122,12 +128,4 @@ class RegistryInstrument(object):
             registry_instrument.ci_version = ci_version
             registry_instrument.guid = guid
             registry_instrument.published_at = published_at
-            is_new = True
-        else:
-            log.info("Registry instrument found, updating", exercise_id=exercise_id, form_type=form_type)
-            registry_instrument.ci_version = ci_version
-            registry_instrument.guid = guid
-            registry_instrument.published_at = published_at
-            is_new = False
-
-        return registry_instrument, is_new
+            return registry_instrument, True

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -88,11 +88,11 @@ class RegistryInstrument(object):
             exercise_id, form_type, session
         ).first()
 
-        if registry_instrument is not None:
-            session.delete(registry_instrument)
-            return True
-        else:
+        if registry_instrument is None:
             return False
+
+        session.delete(registry_instrument)
+        return True
 
     @staticmethod
     def _find_or_create(survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session):

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -14,7 +14,7 @@ log = structlog.wrap_logger(logging.getLogger(__name__))
 
 class RegistryInstrument(object):
     @with_db_session
-    def get_registry_instruments_by_exercise_id(exercise_id, session=None):
+    def get_registry_instruments_by_exercise_id(self, exercise_id, session=None):
         """
         Retrieves a list of selected CIR instruments for the given collection exercise
 
@@ -28,7 +28,7 @@ class RegistryInstrument(object):
         return registry_instruments
 
     @with_db_session
-    def get_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session=None):
+    def get_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
         """
         Retrieves a selected CIR instrument for the given collection exercise and form type
 

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -14,7 +14,7 @@ log = structlog.wrap_logger(logging.getLogger(__name__))
 
 class RegistryInstrument(object):
     @with_db_session
-    def get_registry_instruments_by_exercise_id(exercise_id, session):
+    def get_registry_instruments_by_exercise_id(exercise_id, session=None):
         """
         Retrieves a list of selected CIR instruments for the given collection exercise
 
@@ -24,7 +24,7 @@ class RegistryInstrument(object):
         """
         log.info("Retrieving list of selected CIR instruments", exercise_id=exercise_id)
         validate_uuid(exercise_id)
-        registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session=None)
+        registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session)
         return registry_instruments
 
     @with_db_session

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -20,12 +20,16 @@ class RegistryInstrument(object):
 
         :param exercise_id: An exercise id (UUID)
         :param session: database session
-        :return: list of RegistryInstrumentModel objects
+        :return: a list of RegistryInstrumentModel dictionaries
         """
         log.info("Retrieving list of selected CIR instruments", exercise_id=exercise_id)
         validate_uuid(exercise_id)
         registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session)
-        return registry_instruments
+
+        response = []
+        for registry_instrument in registry_instruments:
+            response.append(registry_instrument.to_dict())
+        return response
 
     @with_db_session
     def get_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
@@ -39,5 +43,10 @@ class RegistryInstrument(object):
         """
         log.info("Retrieving a selected CIR instrument", exercise_id=exercise_id, form_type=form_type)
         validate_uuid(exercise_id)
-        registry_instrument = query_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session)
-        return registry_instrument
+        registry_instrument = query_registry_instrument_by_exercise_id_and_formtype(
+            exercise_id, form_type, session
+        ).first()
+
+        if registry_instrument is not None:
+            return registry_instrument.to_dict()
+        return None

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -57,7 +57,7 @@ class RegistryInstrument(object):
         self, survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session=None
     ):
         """
-        Saves a selected CIR instrument for the given collection exercise and form type
+        Save a selected CIR instrument for the given collection exercise and form type
 
         :param exercise_id: An exercise id (UUID)
         :param form_type: The form type (e.g. "0001")
@@ -78,6 +78,28 @@ class RegistryInstrument(object):
             return True, is_new
         else:
             return False, None
+
+    @with_db_session
+    def delete_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
+        """
+        Delete the selected CIR instrument for the given collection exercise and form type
+
+        :param exercise_id: An exercise id (UUID)
+        :param form_type: The form type (e.g. "0001")
+        :param session: database session
+        :return: A boolean indicating success
+        """
+        log.info("Deleting a selected CIR instrument", exercise_id=exercise_id, form_type=form_type)
+        validate_uuid(exercise_id)
+        registry_instrument = query_registry_instrument_by_exercise_id_and_formtype(
+            exercise_id, form_type, session
+        ).first()
+
+        if registry_instrument is not None:
+            session.delete(registry_instrument)
+            return True
+        else:
+            return False
 
     @staticmethod
     def _find_or_create_registry_instrument(

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -122,16 +122,15 @@ class RegistryInstrument(object):
 
         if not registry_instrument:
             log.info("Registry instrument NOT found, creating new object", exercise_id=exercise_id, form_type=form_type)
-            registry_instrument = RegistryInstrumentModel(
-                survey_id=survey_id,
-                exercise_id=exercise_id,
-                instrument_id=instrument_id,
-                classifier_type="form_type",
-                classifier_value=form_type,
-                ci_version=ci_version,
-                guid=guid,
-                published_at=published_at,
-            )
+            registry_instrument = RegistryInstrumentModel()
+            registry_instrument.survey_id = survey_id
+            registry_instrument.exercise_id = exercise_id
+            registry_instrument.instrument_id = instrument_id
+            registry_instrument.classifier_type = "form_type"
+            registry_instrument.classifier_value = form_type
+            registry_instrument.ci_version = ci_version
+            registry_instrument.guid = guid
+            registry_instrument.published_at = published_at
             is_new = True
         else:
             log.info("Registry instrument found", exercise_id=exercise_id, form_type=form_type)

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -69,15 +69,8 @@ class RegistryInstrument(object):
             survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
         )
 
-        if registry_instrument is not None:
-            if not is_new:
-                registry_instrument.ci_version = ci_version
-                registry_instrument.guid = guid
-                registry_instrument.published_at = published_at
-            session.add(registry_instrument)
-            return True, is_new
-        else:
-            return False, None
+        session.add(registry_instrument)
+        return True, is_new
 
     @with_db_session
     def delete_registry_instrument_by_exercise_id_and_formtype(self, exercise_id, form_type, session=None):
@@ -121,7 +114,7 @@ class RegistryInstrument(object):
         ).first()
 
         if not registry_instrument:
-            log.info("Registry instrument NOT found, creating new object", exercise_id=exercise_id, form_type=form_type)
+            log.info("Registry instrument NOT found, creating", exercise_id=exercise_id, form_type=form_type)
             registry_instrument = RegistryInstrumentModel()
             registry_instrument.survey_id = survey_id
             registry_instrument.exercise_id = exercise_id
@@ -133,7 +126,10 @@ class RegistryInstrument(object):
             registry_instrument.published_at = published_at
             is_new = True
         else:
-            log.info("Registry instrument found", exercise_id=exercise_id, form_type=form_type)
+            log.info("Registry instrument found, updating", exercise_id=exercise_id, form_type=form_type)
+            registry_instrument.ci_version = ci_version
+            registry_instrument.guid = guid
+            registry_instrument.published_at = published_at
             is_new = False
 
         return registry_instrument, is_new

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -3,6 +3,7 @@ import logging
 import structlog
 
 from application.controllers.helper import validate_uuid
+from application.controllers.session_decorator import with_db_session
 from application.controllers.sql_queries import (
     query_registry_instrument_by_exercise_id_and_formtype,
     query_registry_instruments_by_exercise_id,
@@ -12,7 +13,7 @@ log = structlog.wrap_logger(logging.getLogger(__name__))
 
 
 class RegistryInstrument(object):
-    @staticmethod
+    @with_db_session
     def get_registry_instruments_by_exercise_id(exercise_id, session):
         """
         Retrieves a list of selected CIR instruments for the given collection exercise
@@ -23,11 +24,11 @@ class RegistryInstrument(object):
         """
         log.info("Retrieving list of selected CIR instruments", exercise_id=exercise_id)
         validate_uuid(exercise_id)
-        registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session)
+        registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session=None)
         return registry_instruments
 
-    @staticmethod
-    def get_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session):
+    @with_db_session
+    def get_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session=None):
         """
         Retrieves a selected CIR instrument for the given collection exercise and form type
 

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -1,0 +1,42 @@
+import logging
+
+import structlog
+
+from application.controllers.helper import validate_uuid
+from application.controllers.sql_queries import (
+    query_registry_instrument_by_exercise_id_and_formtype,
+    query_registry_instruments_by_exercise_id,
+)
+
+log = structlog.wrap_logger(logging.getLogger(__name__))
+
+
+class RegistryInstrument(object):
+    @staticmethod
+    def get_registry_instruments_by_exercise_id(exercise_id, session):
+        """
+        Retrieves a list of selected CIR instruments for the given collection exercise
+
+        :param exercise_id: An exercise id (UUID)
+        :param session: database session
+        :return: list of RegistryInstrumentModel objects
+        """
+        log.info("Retrieving list of selected CIR instruments", exercise_id=exercise_id)
+        validate_uuid(exercise_id)
+        registry_instruments = query_registry_instruments_by_exercise_id(exercise_id, session)
+        return registry_instruments
+
+    @staticmethod
+    def get_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session):
+        """
+        Retrieves a selected CIR instrument for the given collection exercise and form type
+
+        :param exercise_id: An exercise id (UUID)
+        :param form_type: The form type (e.g. "0001")
+        :param session: database session
+        :return: A RegistryInstrumentModel object
+        """
+        log.info("Retrieving a selected CIR instrument", exercise_id=exercise_id, form_type=form_type)
+        validate_uuid(exercise_id)
+        registry_instrument = query_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session)
+        return registry_instrument

--- a/application/controllers/registry_instrument.py
+++ b/application/controllers/registry_instrument.py
@@ -64,8 +64,9 @@ class RegistryInstrument(object):
         :param session: database session
         :return: True if successful, and is_new indicating if a new object was created
         """
-
-        registry_instrument, is_new = self._find_or_create(
+        log.info("Saving a selected CIR instrument", exercise_id=exercise_id, form_type=form_type)
+        validate_uuid(exercise_id)
+        registry_instrument, is_new = self._find_and_update_or_create(
             survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
         )
 
@@ -95,10 +96,13 @@ class RegistryInstrument(object):
         return True
 
     @staticmethod
-    def _find_or_create(survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session):
+    def _find_and_update_or_create(
+        survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
+    ):
         """
-        Retrieves an existing selected RegistryInstrumentModel object from the db if it exists,
-        or creates a new RegistryInstrumentModel object if it doesn't exist
+        Retrieves an existing selected RegistryInstrumentModel object from the db if it exists
+        and updates it with the selected CIR values,
+        or creates a new RegistryInstrumentModel object with the selected CIR values if it doesn't exist
 
         :param exercise_id: An exercise id (UUID)
         :param form_type: The form type (e.g. "0001")
@@ -106,7 +110,6 @@ class RegistryInstrument(object):
         :return: RegistryInstrumentModel object
         """
 
-        validate_uuid(exercise_id)
         registry_instrument = query_registry_instrument_by_exercise_id_and_formtype(
             exercise_id, form_type, session
         ).first()

--- a/application/controllers/registry_instrument_validator.py
+++ b/application/controllers/registry_instrument_validator.py
@@ -1,0 +1,44 @@
+import datetime
+import re
+
+from application.controllers.helper import validate_uuid
+
+EXPECTED_KEYS = {
+    "survey_id",
+    "exercise_id",
+    "instrument_id",
+    "classifier_type",
+    "classifier_value",
+    "ci_version",
+    "guid",
+    "published_at",
+}
+
+
+def validate_registry_instrument_payload(payload, exercise_id):
+    payload_keys = set(payload.keys())
+    if payload_keys != EXPECTED_KEYS:
+        return False, f"Invalid payload keys. Expected: {EXPECTED_KEYS}"
+    if payload["exercise_id"] != exercise_id:
+        return False, "exercise_id in payload does not match path parameter"
+    if not validate_uuid(exercise_id):
+        return False, "Invalid exercise_id"
+    if not validate_uuid(payload["survey_id"]):
+        return False, "Invalid survey_id"
+    if not validate_uuid(payload["instrument_id"]):
+        return False, "Invalid instrument_id"
+    if payload["classifier_type"] not in ["form_type"]:
+        return False, "Invalid classifier type"
+    if not re.fullmatch(r"\d{4}", str(payload["classifier_value"])):
+        return False, "Invalid classifier value"
+    try:
+        int(payload["ci_version"])
+    except (ValueError, TypeError):
+        return False, "Invalid ci_version"
+    if not validate_uuid(payload["guid"]):
+        return False, "Invalid guid"
+    try:
+        datetime.datetime.fromisoformat(payload["published_at"])
+    except (ValueError, TypeError):
+        return False, "Invalid published_at"
+    return True, None

--- a/application/controllers/registry_instrument_validator.py
+++ b/application/controllers/registry_instrument_validator.py
@@ -17,16 +17,17 @@ EXPECTED_KEYS = {
 
 def validate_registry_instrument_payload(payload, exercise_id):
     payload_keys = set(payload.keys())
+
     if payload_keys != EXPECTED_KEYS:
         return False, f"Invalid payload keys. Expected: {EXPECTED_KEYS}"
     if payload["exercise_id"] != exercise_id:
         return False, "exercise_id in payload does not match path parameter"
-    if not validate_uuid(exercise_id):
-        return False, "Invalid exercise_id"
-    if not validate_uuid(payload["survey_id"]):
-        return False, "Invalid survey_id"
-    if not validate_uuid(payload["instrument_id"]):
-        return False, "Invalid instrument_id"
+
+    validate_uuid(payload["survey_id"])
+    validate_uuid(payload["exercise_id"])
+    validate_uuid(payload["instrument_id"])
+    validate_uuid(payload["guid"])
+
     if payload["classifier_type"] not in ["form_type"]:
         return False, "Invalid classifier type"
     if not re.fullmatch(r"\d{4}", str(payload["classifier_value"])):
@@ -35,8 +36,6 @@ def validate_registry_instrument_payload(payload, exercise_id):
         int(payload["ci_version"])
     except (ValueError, TypeError):
         return False, "Invalid ci_version"
-    if not validate_uuid(payload["guid"]):
-        return False, "Invalid guid"
     try:
         datetime.datetime.fromisoformat(payload["published_at"])
     except (ValueError, TypeError):

--- a/application/controllers/sql_queries.py
+++ b/application/controllers/sql_queries.py
@@ -2,6 +2,7 @@ from application.models.models import (
     BusinessModel,
     ExerciseModel,
     InstrumentModel,
+    RegistryInstrumentModel,
     SurveyModel,
 )
 
@@ -44,4 +45,16 @@ def query_instruments_form_type_with_different_survey_mode(survey_id, form_type,
             InstrumentModel.type != survey_mode,
         )
         .all()
+    )
+
+
+def query_registry_instruments_by_exercise_id(exercise_id, session):
+    return session.query(RegistryInstrumentModel).filter(RegistryInstrumentModel.exercise_id == exercise_id)
+
+
+def query_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type, session):
+    return session.query(RegistryInstrumentModel).filter(
+        RegistryInstrumentModel.exercise_id == exercise_id,
+        RegistryInstrumentModel.classifier_type == "form_type",
+        RegistryInstrumentModel.classifier_value == form_type,
     )

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -217,6 +217,7 @@ class RegistryInstrumentModel(Base):
     classifier_value = Column(String, primary_key=True)
     ci_version = Column(Integer, nullable=False)
     guid = Column(UUID, nullable=False)
+    published_at = Column(TIMESTAMP, nullable=False)
 
     def __init__(
         self,
@@ -227,6 +228,7 @@ class RegistryInstrumentModel(Base):
         classifier_value=None,
         ci_version=None,
         guid=None,
+        published_at=None,
     ):
         """Initialise the class with optionally supplied defaults"""
         self.survey_id = survey_id
@@ -236,3 +238,4 @@ class RegistryInstrumentModel(Base):
         self.classifier_value = classifier_value
         self.ci_version = ci_version
         self.guid = guid
+        self.published_at = published_at

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -239,3 +239,15 @@ class RegistryInstrumentModel(Base):
         self.ci_version = ci_version
         self.guid = guid
         self.published_at = published_at
+
+    def to_dict(self) -> dict:
+        return {
+            "survey_id": self.survey_id,
+            "exercise_id": self.exercise_id,
+            "instrument_id": self.instrument_id,
+            "classifier_type": self.classifier_type,
+            "classifier_value": self.classifier_value,
+            "ci_version": self.ci_version,
+            "guid": self.guid,
+            "published_at": self.published_at.isoformat() if self.published_at else None,
+        }

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -209,10 +209,9 @@ class RegistryInstrumentModel(Base):
 
     # survey_id = Column(UUID, ForeignKey("survey.survey_id"))
     # exercise_id = Column(UUID, ForeignKey("exercise.exercise_id"), primary_key=True)
-    # instrument_id = Column(UUID, ForeignKey("instrument.instrument_id"))
+    instrument_id = Column(UUID, ForeignKey("instrument.instrument_id"))
     survey_id = Column(UUID, nullable=False)
     exercise_id = Column(UUID, primary_key=True)
-    instrument_id = Column(UUID, nullable=False)
     classifier_type = Column(String, primary_key=True)
     classifier_value = Column(String, primary_key=True)
     ci_version = Column(Integer, nullable=False)

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -221,16 +221,16 @@ class RegistryInstrumentModel(Base):
 
     def __init__(
         self,
-        survey_id=None,
-        exercise_id=None,
-        instrument_id=None,
-        classifier_type=None,
-        classifier_value=None,
-        ci_version=None,
-        guid=None,
-        published_at=None,
+        survey_id,
+        exercise_id,
+        instrument_id,
+        classifier_type,
+        classifier_value,
+        ci_version,
+        guid,
+        published_at,
     ):
-        """Initialise the class with optionally supplied defaults"""
+        """Initialise the class with mandatory"""
         self.survey_id = survey_id
         self.exercise_id = exercise_id
         self.instrument_id = instrument_id

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -221,14 +221,14 @@ class RegistryInstrumentModel(Base):
 
     def __init__(
         self,
-        survey_id,
-        exercise_id,
-        instrument_id,
-        classifier_type,
-        classifier_value,
-        ci_version,
-        guid,
-        published_at,
+        survey_id=None,
+        exercise_id=None,
+        instrument_id=None,
+        classifier_type=None,
+        classifier_value=None,
+        ci_version=None,
+        guid=None,
+        published_at=None,
     ):
 
         self.survey_id = survey_id

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -230,7 +230,7 @@ class RegistryInstrumentModel(Base):
         guid,
         published_at,
     ):
-        """Initialise the class with mandatory"""
+
         self.survey_id = survey_id
         self.exercise_id = exercise_id
         self.instrument_id = instrument_id

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -189,3 +189,50 @@ class SEFTModel(Base):
         self.instrument_id = instrument_id
         self.file_name = file_name
         self.len = length
+
+
+class RegistryInstrumentModel(Base):
+    """This models the 'registry_instrument' table which holds the CIR instrument versions
+    selected by the Rops user for each EQ classifier for a given collection exercise.
+
+    * Keyed on the exercise_id, classifier_type and classifier_value, so for any given exercise_id, there can be
+      only one form_type classifier for a given classifier_value
+    * We currently only support "classifier_type": "form_type" (e.g. where "classifier_value" is "0001")
+    * The registry_instrument will only support a single classifier (as text)
+      and not multiple classifier combinations (as json)
+    * In RASRM the survey_id is a UUID, however in the context of the CIR object being returned, their survey_id is
+      what we know of as the three digit survey_ref e.g. "139". This table will hold OUR survey_id as a UUID and
+      not the three digit survey_ref returned by the CIR API.
+    """
+
+    __tablename__ = "registry_instrument"
+
+    # survey_id = Column(UUID, ForeignKey("survey.survey_id"))
+    # exercise_id = Column(UUID, ForeignKey("exercise.exercise_id"), primary_key=True)
+    # instrument_id = Column(UUID, ForeignKey("instrument.instrument_id"))
+    survey_id = Column(UUID, nullable=False)
+    exercise_id = Column(UUID, primary_key=True)
+    instrument_id = Column(UUID, nullable=False)
+    classifier_type = Column(String, primary_key=True)
+    classifier_value = Column(String, primary_key=True)
+    ci_version = Column(Integer, nullable=False)
+    guid = Column(UUID, nullable=False)
+
+    def __init__(
+        self,
+        survey_id=None,
+        exercise_id=None,
+        instrument_id=None,
+        classifier_type=None,
+        classifier_value=None,
+        ci_version=None,
+        guid=None,
+    ):
+        """Initialise the class with optionally supplied defaults"""
+        self.survey_id = survey_id
+        self.exercise_id = exercise_id
+        self.instrument_id = instrument_id
+        self.classifier_type = classifier_type
+        self.classifier_value = classifier_value
+        self.ci_version = ci_version
+        self.guid = guid

--- a/application/models/models.py
+++ b/application/models/models.py
@@ -207,8 +207,6 @@ class RegistryInstrumentModel(Base):
 
     __tablename__ = "registry_instrument"
 
-    # survey_id = Column(UUID, ForeignKey("survey.survey_id"))
-    # exercise_id = Column(UUID, ForeignKey("exercise.exercise_id"), primary_key=True)
     instrument_id = Column(UUID, ForeignKey("instrument.instrument_id"))
     survey_id = Column(UUID, nullable=False)
     exercise_id = Column(UUID, primary_key=True)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -1,0 +1,51 @@
+import logging
+
+import structlog
+from flask import Blueprint, jsonify, make_response
+
+from application.controllers.basic_auth import auth
+from application.controllers.registry_instrument import RegistryInstrument
+
+log = structlog.wrap_logger(logging.getLogger(__name__))
+
+registry_instrument_view = Blueprint("registry_instrument_view", __name__)
+
+
+@registry_instrument_view.before_request
+@auth.login_required
+def before_registry_instrument_view():
+    pass
+
+
+@registry_instrument_view.route("/registryinstrument/exercise-id/<exercise_id>", methods=["GET"])
+def get_registry_instruments(exercise_id):
+    registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
+
+    # stubbing the above until I map the retuened model to the json
+    registry_instruments = {
+        "registry_instruments": [
+            {
+                "exercise_id": exercise_id,
+                "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
+                "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
+                "classifier_type": "form_type",
+                "classifier_value": "0001",
+                "ci_version": 1,
+                "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+            },
+            {
+                "exercise_id": exercise_id,
+                "instrument_id": "77c1e406-716a-488d-bfc9-b5b988fbaccf",
+                "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
+                "classifier_type": "form_type",
+                "classifier_value": "0002",
+                "ci_version": 3,
+                "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
+            },
+        ]
+    }
+
+    if registry_instruments:
+        return make_response(jsonify(registry_instruments), 200)
+
+    return make_response("Not Found", 404)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -27,9 +27,9 @@ def get_registry_instruments(exercise_id):
     registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
 
     if registry_instruments:
-        return make_response(jsonify(registry_instruments), 200)
+        return make_response(jsonify(registry_instruments), HTTPStatus.OK)
 
-    return make_response("Not Found", 404)
+    return make_response("Not Found", HTTPStatus.NOT_FOUND)
 
 
 @registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])
@@ -39,9 +39,9 @@ def get_registry_instrument(exercise_id, form_type):
     )
 
     if registry_instrument:
-        return make_response(jsonify(registry_instrument), 200)
+        return make_response(jsonify(registry_instrument), HTTPStatus.OK)
 
-    return make_response("Not Found", 404)
+    return make_response("Not Found", HTTPStatus.NOT_FOUND)
 
 
 @registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>", methods=["PUT"])
@@ -71,7 +71,7 @@ def put_registry_instrument(exercise_id):
     try:
         payload = request.get_json(force=True)
     except BadRequest:
-        return make_response("Invalid JSON payload", 400)
+        return make_response("Invalid JSON payload", HTTPStatus.BAD_REQUEST)
 
     survey_id = None
     instrument_id = None

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -81,21 +81,14 @@ def put_registry_instrument(exercise_id):
     except BadRequest:
         return make_response("Invalid JSON payload", HTTPStatus.BAD_REQUEST)
 
-    survey_id = None
-    instrument_id = None
-    classifier_value = None
-    ci_version = None
-    guid = None
-    published_at = None
-
     success, is_new = RegistryInstrument().save_registry_instrument_for_exercise_id_and_formtype(
-        survey_id=survey_id,
-        exercise_id=exercise_id,
-        instrument_id=instrument_id,
-        form_type=classifier_value,
-        ci_version=ci_version,
-        published_at=published_at,
-        guid=guid,
+        survey_id=payload["survey_id"],
+        exercise_id=payload["exercise_id"],
+        instrument_id=payload["instrument_id"],
+        form_type=payload["classifier_value"],
+        ci_version=payload["ci_version"],
+        published_at=payload["published_at"],
+        guid=payload["guid"],
     )
 
     if success:

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -31,9 +31,6 @@ def get_registry_instruments(exercise_id):
     """
     registry_instruments = RegistryInstrument().get_by_exercise_id(exercise_id)
 
-    # TODO: (low priority) check the exercise_id exists in the ras_ci.exercise table
-    #       and return 404 if it does not exist
-
     return make_response(jsonify(registry_instruments), HTTPStatus.OK)
 
 

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -76,16 +76,37 @@ def put_registry_instrument(exercise_id):
     survey_id = None
     exercise_id = None
     instrument_id = None
-    classifier_type = None
     classifier_value = None
     ci_version = None
     guid = None
     published_at = None
 
-    # Validate the payload, this will be moved to an appropriate class once stable
+    # -------- Validate the payload --------
+
+    # TODO: this will be all moved to an appropriate class once stable before PR is opened for review
+
+    expected_keys = {
+        "survey_id",
+        "exercise_id",
+        "instrument_id",
+        "classifier_type",
+        "classifier_value",
+        "ci_version",
+        "guid",
+        "published_at",
+    }
+
+    payload_keys = set(payload.keys())
+
+    if payload_keys != expected_keys:
+        return make_response(
+            f"Invalid payload keys. Expected: {expected_keys}, Included: {payload_keys}",
+            400,
+        )
 
     if "classifier_type" in payload:
         classifier_type = payload["classifier_type"]
+        # currently we only support the "form_type" classifier
         if classifier_type not in ["form_type"]:
             return make_response("Invalid classifier type", 400)
 
@@ -130,6 +151,8 @@ def put_registry_instrument(exercise_id):
         if not validate_uuid(exercise_id):
             # TODO: check the exercise_id exists in the ras_ci.exercise table
             return make_response("Invalid exercise_id", 400)
+
+    # -------- Completed validating the payload --------
 
     success, is_new = RegistryInstrument().save_registry_instrument_for_exercise_id_and_formtype(
         survey_id=survey_id,

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -21,34 +21,8 @@ def before_registry_instrument_view():
 def get_registry_instruments(exercise_id):
     registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
 
-    # stubbing the above until I map the returned model to the json
-    stubbed_registry_instruments = {
-        "registry_instruments": [
-            {
-                "exercise_id": exercise_id,
-                "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
-                "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
-                "classifier_type": "form_type",
-                "classifier_value": "0001",
-                "ci_version": 1,
-                "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
-                "published_at": "2025-12-31T00:00:00",
-            },
-            {
-                "exercise_id": exercise_id,
-                "instrument_id": "77c1e406-716a-488d-bfc9-b5b988fbaccf",
-                "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
-                "classifier_type": "form_type",
-                "classifier_value": "0002",
-                "ci_version": 3,
-                "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
-                "published_at": "2025-12-31T12:00:00",
-            },
-        ]
-    }
-
     if registry_instruments:
-        return make_response(jsonify(stubbed_registry_instruments), 200)
+        return make_response(jsonify(registry_instruments), 200)
 
     return make_response("Not Found", 404)
 
@@ -59,19 +33,7 @@ def get_registry_instrument(exercise_id, form_type):
         exercise_id, form_type
     )
 
-    # stubbing the above until I map the returned model to the json
-    stubbed_registry_instrument = {
-        "exercise_id": exercise_id,
-        "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
-        "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
-        "classifier_type": "form_type",
-        "classifier_value": form_type,
-        "ci_version": 1,
-        "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
-        "published_at": "2025-12-31T00:00:00",
-    }
-
     if registry_instrument:
-        return make_response(jsonify(stubbed_registry_instrument), 200)
+        return make_response(jsonify(registry_instrument), 200)
 
     return make_response("Not Found", 404)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -174,3 +174,17 @@ def put_registry_instrument(exercise_id):
             "Registry instrument failed to save successfully",
             HTTPStatus.INTERNAL_SERVER_ERROR,
         )
+
+
+@registry_instrument_view.route(
+    "/registry-instrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["DELETE"]
+)
+def delete_registry_instrument(exercise_id, form_type):
+
+    if RegistryInstrument().delete_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type):
+        return make_response(
+            "Successfully deleted registry instrument",
+            HTTPStatus.OK,
+        )
+    else:
+        return make_response("Not Found", HTTPStatus.NOT_FOUND)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -63,8 +63,8 @@ def put_registry_instrument(exercise_id):
         "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
         "published_at": "2025-12-31T00:00:00",
     }
-    :return: 201 if created successful,
-             200 if updated successful,
+    :return: 201 if created successfully,
+             200 if updated successfully,
              400 if the payload is invalid
     """
 

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -70,11 +70,12 @@ def put_registry_instrument(exercise_id):
 
     try:
         payload = request.get_json(force=True)
-        is_valid, error = validate_registry_instrument_payload(payload, exercise_id)
-        if not is_valid:
-            return make_response(error, HTTPStatus.BAD_REQUEST)
     except BadRequest:
         return make_response("Invalid JSON payload", HTTPStatus.BAD_REQUEST)
+
+    is_valid, error = validate_registry_instrument_payload(payload, exercise_id)
+    if not is_valid:
+        return make_response(error, HTTPStatus.BAD_REQUEST)
 
     success, is_new = RegistryInstrument().save_for_exercise_id_and_formtype(
         survey_id=payload["survey_id"],

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -74,7 +74,6 @@ def put_registry_instrument(exercise_id):
         return make_response("Invalid JSON payload", 400)
 
     survey_id = None
-    exercise_id = None
     instrument_id = None
     classifier_value = None
     ci_version = None
@@ -100,9 +99,28 @@ def put_registry_instrument(exercise_id):
 
     if payload_keys != expected_keys:
         return make_response(
-            f"Invalid payload keys. Expected: {expected_keys}, Included: {payload_keys}",
+            f"Invalid payload keys. Expected: {expected_keys}",
             400,
         )
+
+    if "exercise_id" in payload:
+        if payload["exercise_id"] != exercise_id:
+            return make_response("exercise_id in payload does not match path parameter", 400)
+        if not validate_uuid(exercise_id):
+            # TODO: check the exercise_id exists in the ras_ci.exercise table
+            return make_response("Invalid exercise_id", 400)
+
+    if "survey_id" in payload:
+        survey_id = payload["survey_id"]
+        if not validate_uuid(survey_id):
+            # TODO: check the survey_id exists in the ras_ci.survey table
+            return make_response("Invalid survey_id", 400)
+
+    if "instrument_id" in payload:
+        instrument_id = payload["instrument_id"]
+        if not validate_uuid(instrument_id):
+            # TODO: check the instrument_id exists in the ras_ci.instrument table
+            return make_response("Invalid instrument_id", 400)
 
     if "classifier_type" in payload:
         classifier_type = payload["classifier_type"]
@@ -133,24 +151,6 @@ def put_registry_instrument(exercise_id):
             datetime.datetime.fromisoformat(published_at)
         except (ValueError, TypeError):
             return make_response("Invalid published_at", 400)
-
-    if "survey_id" in payload:
-        survey_id = payload["survey_id"]
-        if not validate_uuid(survey_id):
-            # TODO: check the survey_id exists in the ras_ci.survey table
-            return make_response("Invalid survey_id", 400)
-
-    if "instrument_id" in payload:
-        instrument_id = payload["instrument_id"]
-        if not validate_uuid(instrument_id):
-            # TODO: check the instrument_id exists in the ras_ci.instrument table
-            return make_response("Invalid instrument_id", 400)
-
-    if "exercise_id" in payload:
-        exercise_id = payload["exercise_id"]
-        if not validate_uuid(exercise_id):
-            # TODO: check the exercise_id exists in the ras_ci.exercise table
-            return make_response("Invalid exercise_id", 400)
 
     # -------- Completed validating the payload --------
 

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -21,8 +21,8 @@ def before_registry_instrument_view():
 def get_registry_instruments(exercise_id):
     registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
 
-    # stubbing the above until I map the retuened model to the json
-    registry_instruments = {
+    # stubbing the above until I map the returned model to the json
+    stubbed_registry_instruments = {
         "registry_instruments": [
             {
                 "exercise_id": exercise_id,
@@ -32,6 +32,7 @@ def get_registry_instruments(exercise_id):
                 "classifier_value": "0001",
                 "ci_version": 1,
                 "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+                "published_at": "2025-12-31T00:00:00",
             },
             {
                 "exercise_id": exercise_id,
@@ -41,11 +42,38 @@ def get_registry_instruments(exercise_id):
                 "classifier_value": "0002",
                 "ci_version": 3,
                 "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
+                "published_at": "2025-12-31T12:00:00",
             },
         ]
     }
 
     if registry_instruments:
-        return make_response(jsonify(registry_instruments), 200)
+        return make_response(jsonify(stubbed_registry_instruments), 200)
+
+    return make_response("Not Found", 404)
+
+
+@registry_instrument_view.route("/registryinstrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])
+def get_registry_instrument(exercise_id, form_type):
+    registry_instrument = RegistryInstrument().get_registry_instrument_by_exercise_id_and_formtype(
+        exercise_id, form_type
+    )
+
+    # stubbing the above until I map the returned model to the json
+    stubbed_registry_instrument = {
+        {
+            "exercise_id": exercise_id,
+            "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
+            "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
+            "classifier_type": "form_type",
+            "classifier_value": form_type,
+            "ci_version": 1,
+            "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+            "published_at": "2025-12-31T00:00:00",
+        }
+    }
+
+    if registry_instrument:
+        return make_response(jsonify(stubbed_registry_instrument), 200)
 
     return make_response("Not Found", 404)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -92,11 +92,7 @@ def put_registry_instrument(exercise_id):
             "Successfully saved registry instrument",
             HTTPStatus.CREATED if is_new else HTTPStatus.OK,
         )
-    else:
-        return make_response(
-            "Registry instrument failed to save successfully",
-            HTTPStatus.INTERNAL_SERVER_ERROR,
-        )
+    return make_response("Registry instrument failed to save successfully", HTTPStatus.INTERNAL_SERVER_ERROR)
 
 
 @registry_instrument_view.route(
@@ -109,5 +105,4 @@ def delete_registry_instrument(exercise_id, form_type):
             "Successfully deleted registry instrument",
             HTTPStatus.OK,
         )
-    else:
-        return make_response("Not Found", HTTPStatus.NOT_FOUND)
+    return make_response("Not Found", HTTPStatus.NOT_FOUND)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -98,62 +98,59 @@ def put_registry_instrument(exercise_id):
     payload_keys = set(payload.keys())
 
     if payload_keys != expected_keys:
-        return make_response(
-            f"Invalid payload keys. Expected: {expected_keys}",
-            400,
-        )
+        return make_response(f"Invalid payload keys. Expected: {expected_keys}", HTTPStatus.BAD_REQUEST)
 
     if "exercise_id" in payload:
         if payload["exercise_id"] != exercise_id:
-            return make_response("exercise_id in payload does not match path parameter", 400)
+            return make_response("exercise_id in payload does not match path parameter", HTTPStatus.BAD_REQUEST)
         if not validate_uuid(exercise_id):
             # TODO: check the exercise_id exists in the ras_ci.exercise table
             #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid exercise_id", 400)
+            return make_response("Invalid exercise_id", HTTPStatus.BAD_REQUEST)
 
     if "survey_id" in payload:
         survey_id = payload["survey_id"]
         if not validate_uuid(survey_id):
             # TODO: check the survey_id exists in the ras_ci.survey table
             #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid survey_id", 400)
+            return make_response("Invalid survey_id", HTTPStatus.BAD_REQUEST)
 
     if "instrument_id" in payload:
         instrument_id = payload["instrument_id"]
         if not validate_uuid(instrument_id):
             # TODO: check the instrument_id exists in the ras_ci.instrument table
             #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid instrument_id", 400)
+            return make_response("Invalid instrument_id", HTTPStatus.BAD_REQUEST)
 
     if "classifier_type" in payload:
         classifier_type = payload["classifier_type"]
         # currently we only support the "form_type" classifier
         if classifier_type not in ["form_type"]:
-            return make_response("Invalid classifier type", 400)
+            return make_response("Invalid classifier type", HTTPStatus.BAD_REQUEST)
 
     if "classifier_value" in payload:
         classifier_value = payload["classifier_value"]
         if not re.fullmatch(r"\d{4}", str(classifier_value)):
-            return make_response("Invalid classifier value", 400)
+            return make_response("Invalid classifier value", HTTPStatus.BAD_REQUEST)
 
     if "ci_version" in payload:
         ci_version = payload["ci_version"]
         try:
             ci_version = int(ci_version)
         except (ValueError, TypeError):
-            return make_response("Invalid ci_version", 400)
+            return make_response("Invalid ci_version", HTTPStatus.BAD_REQUEST)
 
     if "guid" in payload:
         guid = payload["guid"]
         if not validate_uuid(guid):
-            return make_response("Invalid guid", 400)
+            return make_response("Invalid guid", HTTPStatus.BAD_REQUEST)
 
     if "published_at" in payload:
         published_at = payload["published_at"]
         try:
             datetime.datetime.fromisoformat(published_at)
         except (ValueError, TypeError):
-            return make_response("Invalid published_at", 400)
+            return make_response("Invalid published_at", HTTPStatus.BAD_REQUEST)
 
     # -------- Completed validating the payload --------
 

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -17,7 +17,7 @@ def before_registry_instrument_view():
     pass
 
 
-@registry_instrument_view.route("/registryinstrument/exercise-id/<exercise_id>", methods=["GET"])
+@registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>", methods=["GET"])
 def get_registry_instruments(exercise_id):
     registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
 
@@ -53,7 +53,7 @@ def get_registry_instruments(exercise_id):
     return make_response("Not Found", 404)
 
 
-@registry_instrument_view.route("/registryinstrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])
+@registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])
 def get_registry_instrument(exercise_id, form_type):
     registry_instrument = RegistryInstrument().get_registry_instrument_by_exercise_id_and_formtype(
         exercise_id, form_type
@@ -61,7 +61,6 @@ def get_registry_instrument(exercise_id, form_type):
 
     # stubbing the above until I map the returned model to the json
     stubbed_registry_instrument = {
-        {
             "exercise_id": exercise_id,
             "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
             "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
@@ -71,7 +70,6 @@ def get_registry_instrument(exercise_id, form_type):
             "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
             "published_at": "2025-12-31T00:00:00",
         }
-    }
 
     if registry_instrument:
         return make_response(jsonify(stubbed_registry_instrument), 200)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -61,15 +61,15 @@ def get_registry_instrument(exercise_id, form_type):
 
     # stubbing the above until I map the returned model to the json
     stubbed_registry_instrument = {
-            "exercise_id": exercise_id,
-            "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
-            "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
-            "classifier_type": "form_type",
-            "classifier_value": form_type,
-            "ci_version": 1,
-            "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
-            "published_at": "2025-12-31T00:00:00",
-        }
+        "exercise_id": exercise_id,
+        "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
+        "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e",
+        "classifier_type": "form_type",
+        "classifier_value": form_type,
+        "ci_version": 1,
+        "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+        "published_at": "2025-12-31T00:00:00",
+    }
 
     if registry_instrument:
         return make_response(jsonify(stubbed_registry_instrument), 200)

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -108,18 +108,21 @@ def put_registry_instrument(exercise_id):
             return make_response("exercise_id in payload does not match path parameter", 400)
         if not validate_uuid(exercise_id):
             # TODO: check the exercise_id exists in the ras_ci.exercise table
+            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
             return make_response("Invalid exercise_id", 400)
 
     if "survey_id" in payload:
         survey_id = payload["survey_id"]
         if not validate_uuid(survey_id):
             # TODO: check the survey_id exists in the ras_ci.survey table
+            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
             return make_response("Invalid survey_id", 400)
 
     if "instrument_id" in payload:
         instrument_id = payload["instrument_id"]
         if not validate_uuid(instrument_id):
             # TODO: check the instrument_id exists in the ras_ci.instrument table
+            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
             return make_response("Invalid instrument_id", 400)
 
     if "classifier_type" in payload:

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -1,6 +1,4 @@
-import datetime
 import logging
-import re
 from http import HTTPStatus
 
 import structlog
@@ -8,8 +6,10 @@ from flask import Blueprint, jsonify, make_response, request
 from werkzeug.exceptions import BadRequest
 
 from application.controllers.basic_auth import auth
-from application.controllers.helper import validate_uuid
 from application.controllers.registry_instrument import RegistryInstrument
+from application.controllers.registry_instrument_validator import (
+    validate_registry_instrument_payload,
+)
 
 log = structlog.wrap_logger(logging.getLogger(__name__))
 
@@ -57,7 +57,7 @@ def put_registry_instrument(exercise_id):
     We currently only support "classifier_type": "form_type" (e.g. where "classifier_value" is "0001").
 
     :param exercise_id: An exercise id (UUID)
-    :payload format example
+    :valid payload format example
     {
         "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
         "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
@@ -75,6 +75,9 @@ def put_registry_instrument(exercise_id):
 
     try:
         payload = request.get_json(force=True)
+        is_valid, error = validate_registry_instrument_payload(payload, exercise_id)
+        if not is_valid:
+            return make_response(error, HTTPStatus.BAD_REQUEST)
     except BadRequest:
         return make_response("Invalid JSON payload", HTTPStatus.BAD_REQUEST)
 
@@ -84,80 +87,6 @@ def put_registry_instrument(exercise_id):
     ci_version = None
     guid = None
     published_at = None
-
-    # -------- Validate the payload --------
-
-    # TODO: this will be all moved to an appropriate class once stable before PR is opened for review
-
-    expected_keys = {
-        "survey_id",
-        "exercise_id",
-        "instrument_id",
-        "classifier_type",
-        "classifier_value",
-        "ci_version",
-        "guid",
-        "published_at",
-    }
-
-    payload_keys = set(payload.keys())
-
-    if payload_keys != expected_keys:
-        return make_response(f"Invalid payload keys. Expected: {expected_keys}", HTTPStatus.BAD_REQUEST)
-
-    if "exercise_id" in payload:
-        if payload["exercise_id"] != exercise_id:
-            return make_response("exercise_id in payload does not match path parameter", HTTPStatus.BAD_REQUEST)
-        if not validate_uuid(exercise_id):
-            # TODO: check the exercise_id exists in the ras_ci.exercise table
-            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid exercise_id", HTTPStatus.BAD_REQUEST)
-
-    if "survey_id" in payload:
-        survey_id = payload["survey_id"]
-        if not validate_uuid(survey_id):
-            # TODO: check the survey_id exists in the ras_ci.survey table
-            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid survey_id", HTTPStatus.BAD_REQUEST)
-
-    if "instrument_id" in payload:
-        instrument_id = payload["instrument_id"]
-        if not validate_uuid(instrument_id):
-            # TODO: check the instrument_id exists in the ras_ci.instrument table
-            #       once the constraint is in place we could just rely on SQLAlchemy exception handling
-            return make_response("Invalid instrument_id", HTTPStatus.BAD_REQUEST)
-
-    if "classifier_type" in payload:
-        classifier_type = payload["classifier_type"]
-        # currently we only support the "form_type" classifier
-        if classifier_type not in ["form_type"]:
-            return make_response("Invalid classifier type", HTTPStatus.BAD_REQUEST)
-
-    if "classifier_value" in payload:
-        classifier_value = payload["classifier_value"]
-        if not re.fullmatch(r"\d{4}", str(classifier_value)):
-            return make_response("Invalid classifier value", HTTPStatus.BAD_REQUEST)
-
-    if "ci_version" in payload:
-        ci_version = payload["ci_version"]
-        try:
-            ci_version = int(ci_version)
-        except (ValueError, TypeError):
-            return make_response("Invalid ci_version", HTTPStatus.BAD_REQUEST)
-
-    if "guid" in payload:
-        guid = payload["guid"]
-        if not validate_uuid(guid):
-            return make_response("Invalid guid", HTTPStatus.BAD_REQUEST)
-
-    if "published_at" in payload:
-        published_at = payload["published_at"]
-        try:
-            datetime.datetime.fromisoformat(published_at)
-        except (ValueError, TypeError):
-            return make_response("Invalid published_at", HTTPStatus.BAD_REQUEST)
-
-    # -------- Completed validating the payload --------
 
     success, is_new = RegistryInstrument().save_registry_instrument_for_exercise_id_and_formtype(
         survey_id=survey_id,

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -29,7 +29,7 @@ def get_registry_instruments(exercise_id):
 
     :param exercise_id: An exercise id (UUID)
     """
-    registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
+    registry_instruments = RegistryInstrument().get_by_exercise_id(exercise_id)
 
     # TODO: (low priority) check the exercise_id exists in the ras_ci.exercise table
     #       and return 404 if it does not exist
@@ -39,9 +39,7 @@ def get_registry_instruments(exercise_id):
 
 @registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])
 def get_registry_instrument(exercise_id, form_type):
-    registry_instrument = RegistryInstrument().get_registry_instrument_by_exercise_id_and_formtype(
-        exercise_id, form_type
-    )
+    registry_instrument = RegistryInstrument().get_by_exercise_id_and_formtype(exercise_id, form_type)
 
     if registry_instrument:
         return make_response(jsonify(registry_instrument), HTTPStatus.OK)
@@ -81,7 +79,7 @@ def put_registry_instrument(exercise_id):
     except BadRequest:
         return make_response("Invalid JSON payload", HTTPStatus.BAD_REQUEST)
 
-    success, is_new = RegistryInstrument().save_registry_instrument_for_exercise_id_and_formtype(
+    success, is_new = RegistryInstrument().save_for_exercise_id_and_formtype(
         survey_id=payload["survey_id"],
         exercise_id=payload["exercise_id"],
         instrument_id=payload["instrument_id"],
@@ -108,7 +106,7 @@ def put_registry_instrument(exercise_id):
 )
 def delete_registry_instrument(exercise_id, form_type):
 
-    if RegistryInstrument().delete_registry_instrument_by_exercise_id_and_formtype(exercise_id, form_type):
+    if RegistryInstrument().delete_by_exercise_id_and_formtype(exercise_id, form_type):
         return make_response(
             "Successfully deleted registry instrument",
             HTTPStatus.OK,

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -1,9 +1,13 @@
+import datetime
 import logging
+import re
 
 import structlog
-from flask import Blueprint, jsonify, make_response
+from flask import Blueprint, jsonify, make_response, request
+from werkzeug.exceptions import BadRequest
 
 from application.controllers.basic_auth import auth
+from application.controllers.helper import validate_uuid
 from application.controllers.registry_instrument import RegistryInstrument
 
 log = structlog.wrap_logger(logging.getLogger(__name__))
@@ -37,3 +41,111 @@ def get_registry_instrument(exercise_id, form_type):
         return make_response(jsonify(registry_instrument), 200)
 
     return make_response("Not Found", 404)
+
+
+@registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>", methods=["POST"])
+def post_registry_instrument(exercise_id):
+    """
+    Create a selected CIR instrument for the given collection exercise
+
+    :param exercise_id: An exercise id (UUID)
+    :return: HTTP Status 201 if successful,
+             400 if the payload is invalid,
+             409 if a selected registry instrument already exists
+    :payload format example
+    {
+        "ci_version": 1,
+        "classifier_type": "form_type",
+        "classifier_value": "0001",
+        "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
+        "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+        "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
+        "published_at": "2025-12-31T00:00:00",
+        "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
+    }
+    """
+
+    try:
+        payload = request.get_json(force=True)
+    except BadRequest:
+        return make_response("Invalid JSON payload", 400)
+
+    survey_id = None
+    exercise_id = None
+    instrument_id = None
+    classifier_type = None
+    classifier_value = None
+    ci_version = None
+    guid = None
+    published_at = None
+
+    if "classifier_type" in payload:
+        classifier_type = payload["classifier_type"]
+        if classifier_type not in ["form_type"]:
+            return make_response("Invalid classifier type", 400)
+
+    if "classifier_value" in payload:
+        classifier_value = payload["classifier_value"]
+        if not re.fullmatch(r"\d{4}", str(classifier_value)):
+            return make_response("Invalid classifier value", 400)
+
+    if "ci_version" in payload:
+        ci_version = payload["ci_version"]
+        try:
+            ci_version = int(ci_version)
+        except (ValueError, TypeError):
+            return make_response("Invalid ci_version", 400)
+
+    if "guid" in payload:
+        guid = payload["guid"]
+        if not validate_uuid(guid):
+            return make_response("Invalid guid", 400)
+
+    if "published_at" in payload:
+        published_at = payload["published_at"]
+        try:
+            datetime.datetime.fromisoformat(published_at)
+        except (ValueError, TypeError):
+            return make_response("Invalid published_at", 400)
+
+    if "survey_id" in payload:
+        survey_id = payload["survey_id"]
+        if not validate_uuid(survey_id):
+            # TODO: check the survey_id exists in the ras_ci.survey table
+            return make_response("Invalid survey_id", 400)
+
+    if "instrument_id" in payload:
+        instrument_id = payload["instrument_id"]
+        if not validate_uuid(instrument_id):
+            # TODO: check the instrument_id exists in the ras_ci.instrument table
+            return make_response("Invalid instrument_id", 400)
+
+    if "exercise_id" in payload:
+        exercise_id = payload["exercise_id"]
+        if not validate_uuid(exercise_id):
+            # TODO: check the exercise_id exists in the ras_ci.exercise table
+            return make_response("Invalid exercise_id", 400)
+
+    registry_instrument = RegistryInstrument().get_registry_instrument_by_exercise_id_and_formtype(
+        exercise_id, payload["classifier_value"]
+    )
+
+    if registry_instrument:
+        return make_response("A selected registry instrument already exists for this exercise_id and form_type", 409)
+
+    log.info(
+        "The selected registry instrument would have been created, but the persistence layer is not implemented yet",
+        survey_id=survey_id,
+        exercise_id=exercise_id,
+        instrument_id=instrument_id,
+        classifier_type=classifier_type,
+        classifier_value=classifier_value,
+        ci_version=ci_version,
+        published_at=published_at,
+        guid=guid,
+    )
+
+    return make_response(
+        "The selected registry instrument would have been created, but the persistence layer is not implemented yet",
+        201,
+    )

--- a/application/views/registry_instrument_view.py
+++ b/application/views/registry_instrument_view.py
@@ -24,12 +24,17 @@ def before_registry_instrument_view():
 
 @registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>", methods=["GET"])
 def get_registry_instruments(exercise_id):
+    """
+    Returns an array of selected CIR instrument for the given collection exercise.
+
+    :param exercise_id: An exercise id (UUID)
+    """
     registry_instruments = RegistryInstrument().get_registry_instruments_by_exercise_id(exercise_id)
 
-    if registry_instruments:
-        return make_response(jsonify(registry_instruments), HTTPStatus.OK)
+    # TODO: (low priority) check the exercise_id exists in the ras_ci.exercise table
+    #       and return 404 if it does not exist
 
-    return make_response("Not Found", HTTPStatus.NOT_FOUND)
+    return make_response(jsonify(registry_instruments), HTTPStatus.OK)
 
 
 @registry_instrument_view.route("/registry-instrument/exercise-id/<exercise_id>/formtype/<form_type>", methods=["GET"])

--- a/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
+++ b/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
@@ -33,6 +33,10 @@ def upgrade():
         schema="ras_ci",
     )
 
+    op.create_index(
+        "ix_registry_instrument_exercise_id", "registry_instrument", ["instrument_id"], unique=False, schema="ras_ci"
+    )
+
 
 def downgrade():
     op.drop_table("registry_instrument", schema="ras_ci")

--- a/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
+++ b/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
@@ -1,0 +1,38 @@
+"""Add registry_instrument table
+
+Revision ID: b730b3a81f72
+Revises: f55291dd84c0
+Create Date: 2022-08-10 15:02:35.189420
+
+"""
+
+import sqlalchemy as sqlalchemy
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b730b3a81f72"
+down_revision = "f55291dd84c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "registry_instrument",
+        sqlalchemy.Column("survey_id", sqlalchemy.UUID, nullable=False),
+        sqlalchemy.Column("exercise_id", sqlalchemy.UUID, primary_key=True),
+        sqlalchemy.Column("instrument_id", sqlalchemy.UUID, nullable=False),
+        sqlalchemy.Column("classifier_type", sqlalchemy.String, primary_key=True),
+        sqlalchemy.Column("classifier_value", sqlalchemy.String, primary_key=True),
+        sqlalchemy.Column("ci_version", sqlalchemy.Integer, nullable=False),
+        sqlalchemy.Column("guid", sqlalchemy.UUID, nullable=False),
+        sqlalchemy.Column("published_at", sqlalchemy.TIMESTAMP, nullable=False),
+        # sqlalchemy.ForeignKeyConstraint(["survey_id"], ["ras_ci.survey.survey_id"]),
+        # sqlalchemy.ForeignKeyConstraint(["exercise_id"], ["ras_ci.exercise.exercise_id"]),
+        # sqlalchemy.ForeignKeyConstraint(["instrument_id"], ["ras_ci.instrument.instrument_id"]),
+        schema="ras_ci",
+    )
+
+
+def downgrade():
+    op.drop_table("registry_instrument", schema="ras_ci")

--- a/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
+++ b/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
@@ -29,7 +29,7 @@ def upgrade():
         sqlalchemy.Column("published_at", sqlalchemy.TIMESTAMP, nullable=False),
         # sqlalchemy.ForeignKeyConstraint(["survey_id"], ["ras_ci.survey.survey_id"]),
         # sqlalchemy.ForeignKeyConstraint(["exercise_id"], ["ras_ci.exercise.exercise_id"]),
-        # sqlalchemy.ForeignKeyConstraint(["instrument_id"], ["ras_ci.instrument.instrument_id"]),
+        sqlalchemy.ForeignKeyConstraint(["instrument_id"], ["ras_ci.instrument.instrument_id"]),
         schema="ras_ci",
     )
 

--- a/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
+++ b/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
@@ -27,8 +27,6 @@ def upgrade():
         sqlalchemy.Column("ci_version", sqlalchemy.Integer, nullable=False),
         sqlalchemy.Column("guid", sqlalchemy.UUID, nullable=False),
         sqlalchemy.Column("published_at", sqlalchemy.TIMESTAMP, nullable=False),
-        # sqlalchemy.ForeignKeyConstraint(["survey_id"], ["ras_ci.survey.survey_id"]),
-        # sqlalchemy.ForeignKeyConstraint(["exercise_id"], ["ras_ci.exercise.exercise_id"]),
         sqlalchemy.ForeignKeyConstraint(["instrument_id"], ["ras_ci.instrument.instrument_id"]),
         schema="ras_ci",
     )

--- a/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
+++ b/migrations/versions/b730b3a81f72_add_registry_instrument_table.py
@@ -34,7 +34,7 @@ def upgrade():
     )
 
     op.create_index(
-        "ix_registry_instrument_exercise_id", "registry_instrument", ["instrument_id"], unique=False, schema="ras_ci"
+        "ix_registry_instrument_exercise_id", "registry_instrument", ["exercise_id"], unique=False, schema="ras_ci"
     )
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: collection instrument
-  description: A service for the managing collection instrument service resources
+  description: An API for managing collection instrument service resources
   version: "1.0"
 
 servers:
@@ -428,7 +428,7 @@ paths:
                     type: string
                     format: uuid
                     example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
-  "/collection-instrument-api/1.0.2/registryinstrument/exercise_id/{exercise_id}":
+  "/collection-instrument-api/1.0.2/registryinstrument/exercise-id/{exercise_id}":
     get:
       summary: Get a list of selected registry instruments for the given exercise UUID.
       tags:
@@ -453,7 +453,7 @@ paths:
                   $ref: '#/components/schemas/RegistryInstrument'
         '404':
           description: No registry instruments found for the given exercise ID
-  "/collection-instrument-api/1.0.2/registryinstrument/exercise_id/{exercise_id}/form_type/{form_type}":
+  "/collection-instrument-api/1.0.2/registryinstrument/exercise-id/{exercise_id}/formtype/{form_type}":
     get:
       summary: Get a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:
@@ -679,6 +679,8 @@ components:
         guid:
           type: string
           format: uuid
-
+        published_at:
+          type: string
+          format: date-time
 security:
   - basicAuth: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -428,7 +428,7 @@ paths:
                     type: string
                     format: uuid
                     example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
-  "/collection-instrument-api/1.0.2/registryinstrument/exercise-id/{exercise_id}":
+  "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}":
     get:
       summary: Get a list of selected registry instruments for the given exercise UUID.
       tags:
@@ -453,7 +453,7 @@ paths:
                   $ref: '#/components/schemas/RegistryInstrument'
         '404':
           description: No registry instruments found for the given exercise ID
-  "/collection-instrument-api/1.0.2/registryinstrument/exercise-id/{exercise_id}/formtype/{form_type}":
+  "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type}":
     put:
       summary: Save a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -458,12 +458,39 @@ paths:
       summary: Save a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:
         - registry-instrument
+      parameters:
+        - in: path
+          name: exercise_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
+          description: The collection exercise UUID.
+      requestBody:
+        description: The registry instrument to save.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegistryInstrument'
+      responses:
+        '200':
+          description: Returns the result of the request to save the registry instrument for the given exercise UUID.
+          content:
+            application/text:
+              schema:
+                type: string
+                example: 'Successfully saved registry instrument'
+        '201':
+          description: Returns the result of the request to save the registry instrument for the given exercise UUID.
+          content:
+            application/text:
+              schema:
+                type: string
+                example: 'Successfully saved registry instrument'
     delete:
       summary: Deletes a selected registry instrument for the given exercise UUID and form type classifier value.
-      tags:
-        - registry-instrument
-    patch:
-      summary: Updates the selected registry instrument for the given exercise UUID and form type classifier value.
       tags:
         - registry-instrument
     get:
@@ -683,8 +710,9 @@ components:
           format: uuid
         classifier_type:
           type: string
-          enum: [FORM_TYPE]
+          enum: [form_type]
         classifier_value:
+          pattern: '^\d{4}$'
           type: string
         ci_version:
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: collection instrument
-  description: A service for the uploading of collection instruments and exercises
+  description: A service for the managing collection instrument service resources
   version: "1.0"
 
 servers:
@@ -15,6 +15,8 @@ tags:
     description: Service information endpoints
   - name: survey-response
     description: Survey response endpoints
+  - name: registry-instrument
+    description: Endpoints for managing registry instrument resources selected in collection exercises
 
 paths:
   "/collection-instrument-api/1.0.2/upload/{exercise_id}/{RU_id}":
@@ -426,6 +428,64 @@ paths:
                     type: string
                     format: uuid
                     example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
+  "/collection-instrument-api/1.0.2/registryinstrument/exercise_id/{exercise_id}":
+    get:
+      summary: Get a list of selected registry instruments for the given exercise UUID.
+      tags:
+        - registry-instrument
+      parameters:
+        - in: path
+          name: exercise_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
+          description: The collection exercise ID.
+      responses:
+        '200':
+          description: Returns a list of selected registry instruments for the given exercise UUID.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistryInstrument'
+        '404':
+          description: No registry instruments found for the given exercise ID
+  "/collection-instrument-api/1.0.2/registryinstrument/exercise_id/{exercise_id}/form_type/{form_type}":
+    get:
+      summary: Get a selected registry instrument for the given exercise UUID and form type classifier value.
+      tags:
+        - registry-instrument
+      parameters:
+        - in: path
+          name: exercise_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
+          description: The collection exercise UUID.
+        - in: path
+          name: form_type
+          required: true
+          schema:
+            type: string
+            pattern: '^\d{4}$'
+            example: '0123'
+          description: The form type classifier value.
+      responses:
+        '200':
+          description: Returns the selected registry instrument for the given exercise UUID and form type classifier value.
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  $ref: '#/components/schemas/RegistryInstrument'
+        '404':
+          description: No registry instrument found for the given exercise UUID and form type classifier value.
   "/collection-instrument-api/1.0.2/collectioninstrument/id/{instrument_id}":
     get:
       summary: Get collection instrument by instrument ID
@@ -597,5 +657,28 @@ components:
               type: string
             cell_no:
               type: integer
+    RegistryInstrument:
+      type: object
+      properties:
+        survey_id:
+          type: string
+          format: uuid
+        exercise_id:
+          type: string
+          format: uuid
+        instrument_id:
+          type: string
+          format: uuid
+        classifier_type:
+          type: string
+          enum: [FORM_TYPE]
+        classifier_value:
+          type: string
+        ci_version:
+          type: integer
+        guid:
+          type: string
+          format: uuid
+
 security:
   - basicAuth: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -479,7 +479,7 @@ paths:
           description: The collection exercise ID.
       responses:
         '200':
-          description: Returns a list of selected registry instruments for the given exercise UUID.
+          description: Returns a list of selected registry instruments for the given exercise UUID, and an empty list if no registry instruments have been selected for the exercise UUID.
           content:
             application/json:
               schema:
@@ -487,7 +487,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/RegistryInstrument'
         '404':
-          description: No registry instruments found for the given exercise ID
+          description: The given exercise ID does not exist
   "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type}":
     get:
       summary: Get a selected registry instrument for the given exercise UUID and form type classifier value.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -454,6 +454,18 @@ paths:
         '404':
           description: No registry instruments found for the given exercise ID
   "/collection-instrument-api/1.0.2/registryinstrument/exercise-id/{exercise_id}/formtype/{form_type}":
+    put:
+      summary: Save a selected registry instrument for the given exercise UUID and form type classifier value.
+      tags:
+        - registry-instrument
+    delete:
+      summary: Deletes a selected registry instrument for the given exercise UUID and form type classifier value.
+      tags:
+        - registry-instrument
+    patch:
+      summary: Updates the selected registry instrument for the given exercise UUID and form type classifier value.
+      tags:
+        - registry-instrument
     get:
       summary: Get a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -429,33 +429,8 @@ paths:
                     format: uuid
                     example: 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87'
   "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}":
-    get:
-      summary: Get a list of selected registry instruments for the given exercise UUID.
-      tags:
-        - registry-instrument
-      parameters:
-        - in: path
-          name: exercise_id
-          required: true
-          schema:
-            type: string
-            format: uuid
-            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
-          description: The collection exercise ID.
-      responses:
-        '200':
-          description: Returns a list of selected registry instruments for the given exercise UUID.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RegistryInstrument'
-        '404':
-          description: No registry instruments found for the given exercise ID
-  "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type}":
     put:
-      summary: Save a selected registry instrument for the given exercise UUID and form type classifier value.
+      summary: Save a selected registry instrument for the given exercise UUID.
       tags:
         - registry-instrument
       parameters:
@@ -489,10 +464,31 @@ paths:
               schema:
                 type: string
                 example: 'Successfully saved registry instrument'
-    delete:
-      summary: Deletes a selected registry instrument for the given exercise UUID and form type classifier value.
+    get:
+      summary: Get a list of selected registry instruments for the given exercise UUID.
       tags:
         - registry-instrument
+      parameters:
+        - in: path
+          name: exercise_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
+          description: The collection exercise ID.
+      responses:
+        '200':
+          description: Returns a list of selected registry instruments for the given exercise UUID.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistryInstrument'
+        '404':
+          description: No registry instruments found for the given exercise ID
+  "/collection-instrument-api/1.0.2/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type}":
     get:
       summary: Get a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:
@@ -525,6 +521,10 @@ paths:
                   $ref: '#/components/schemas/RegistryInstrument'
         '404':
           description: No registry instrument found for the given exercise UUID and form type classifier value.
+    delete:
+      summary: Deletes a selected registry instrument for the given exercise UUID and form type classifier value.
+      tags:
+        - registry-instrument
   "/collection-instrument-api/1.0.2/collectioninstrument/id/{instrument_id}":
     get:
       summary: Get collection instrument by instrument ID

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -41,7 +41,7 @@ paths:
             format: uuid
             example: 'test_ru_ref'
           description: The RU reference
-        - in : query
+        - in: query
           name: file
           required: true
           schema:
@@ -361,9 +361,9 @@ paths:
           description: Returns the collection instrument matching the instrument ID
           content:
             text/plain:
-                schema:
-                  type: string
-                  example: "The patch of the instrument was successful"
+              schema:
+                type: string
+                example: "The patch of the instrument was successful"
         '400':
           description: Request error (not found, missing filename, not a seft instrument)
           content:
@@ -374,7 +374,7 @@ paths:
                   error:
                     type: string
                     format: dictionary
-                    example: ["Missing filename"]
+                    example: [ "Missing filename" ]
         '500':
           description: An external service returned a HTTPError
         '503':
@@ -525,6 +525,33 @@ paths:
       summary: Deletes a selected registry instrument for the given exercise UUID and form type classifier value.
       tags:
         - registry-instrument
+      parameters:
+        - in: path
+          name: exercise_id
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 'fb2a9d3a-6e9c-46f6-af5e-5f67fec3c040'
+          description: The collection exercise UUID.
+        - in: path
+          name: form_type
+          required: true
+          schema:
+            type: string
+            pattern: '^\d{4}$'
+            example: '0123'
+          description: The form type classifier value.
+      responses:
+        '200':
+          description: Returns the result of the request to delete the registry instrument for the given exercise UUID and form type.
+          content:
+            application/text:
+              schema:
+                type: string
+                example: 'Successfully deleted registry instrument'
+        '404':
+          description: No registry instrument found for the given exercise UUID and form type classifier value.
   "/collection-instrument-api/1.0.2/collectioninstrument/id/{instrument_id}":
     get:
       summary: Get collection instrument by instrument ID
@@ -587,9 +614,9 @@ paths:
           description: Successfully deleted the collection instrument
           content:
             text/plain:
-                schema:
-                  type: string
-                  example: "SEFT collection instrument deleted successfully"
+              schema:
+                type: string
+                example: "SEFT collection instrument deleted successfully"
         '404':
           description: Collection instrument not found
         '500':

--- a/run.py
+++ b/run.py
@@ -35,6 +35,10 @@ def create_app(config=None, init_db=True):
 
     app.register_blueprint(info_view)
 
+    from application.views.registry_instrument_view import registry_instrument_view
+    
+    app.register_blueprint(registry_instrument_view)
+
     from application.error_handlers import error_blueprint
 
     app.register_blueprint(error_blueprint)

--- a/run.py
+++ b/run.py
@@ -36,8 +36,8 @@ def create_app(config=None, init_db=True):
     app.register_blueprint(info_view)
 
     from application.views.registry_instrument_view import registry_instrument_view
-    
-    app.register_blueprint(registry_instrument_view)
+
+    app.register_blueprint(registry_instrument_view, url_prefix="/collection-instrument-api/1.0.2")
 
     from application.error_handlers import error_blueprint
 

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -2,13 +2,13 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from application.controllers.registry_instrument import RegistryInstrument
+from application.exceptions import RasError
 
 
 class TestRegistryInstrumentController(TestCase):
 
     @patch("application.controllers.registry_instrument.query_registry_instruments_by_exercise_id")
-    @patch("application.controllers.registry_instrument.validate_uuid")
-    def test_get_registry_instruments_by_exercise_id_returns_list_of_dicts(self, mock_validate_uuid, mock_query):
+    def test_get_registry_instruments_by_exercise_id_returns_list_of_dicts(self, mock_query):
 
         session = MagicMock()
 
@@ -25,9 +25,61 @@ class TestRegistryInstrumentController(TestCase):
 
         result = controller.get_registry_instruments_by_exercise_id.__wrapped__(controller, exercise_id, session)
 
-        mock_validate_uuid.assert_called_once_with(exercise_id)
         mock_query.assert_called_once()
 
         self.assertEqual(result, [{"dummy_key": "dummy_value_1"}, {"dummy_key": "dummy_value_2"}])
         mock_registry_instrument1.to_dict.assert_called_once()
         mock_registry_instrument2.to_dict.assert_called_once()
+
+    @patch("application.controllers.registry_instrument.query_registry_instruments_by_exercise_id")
+    def test_get_registry_instruments_by_exercise_id_throws_exception_when_uuid_invalid(self, mock_query):
+        session = MagicMock()
+
+        controller = RegistryInstrument()
+        exercise_id = "invalid_uuid"
+
+        with self.assertRaises(RasError) as context:
+            controller.get_registry_instruments_by_exercise_id.__wrapped__(controller, exercise_id, session)
+
+        self.assertEqual(context.exception.errors[0], "Value is not a valid UUID (invalid_uuid)")
+
+    @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")
+    def test_get_registry_instrument_by_exercise_id_and_formtype_returns_dict(self, mock_query):
+
+        session = MagicMock()
+
+        mock_registry_instrument = MagicMock()
+        mock_registry_instrument.to_dict.return_value = {"dummy_key": "dummy_value_1"}
+        mock_query.return_value.first.return_value = mock_registry_instrument
+
+        controller = RegistryInstrument()
+        exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
+        formtype = "0001"
+
+        result = controller.get_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
+            controller, exercise_id, formtype, session
+        )
+
+        mock_query.assert_called_once()
+        mock_registry_instrument.to_dict.assert_called_once()
+        self.assertEqual(result, {"dummy_key": "dummy_value_1"})
+
+    @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")
+    def test_get_registry_instrument_by_exercise_id_and_formtype_returns_none(self, mock_query):
+
+        session = MagicMock()
+
+        mock_registry_instrument = MagicMock()
+        mock_query.return_value.first.return_value = None
+
+        controller = RegistryInstrument()
+        exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
+        formtype = "0001"
+
+        result = controller.get_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
+            controller, exercise_id, formtype, session
+        )
+
+        mock_query.assert_called_once()
+        mock_registry_instrument.to_dict.assert_not_called()
+        self.assertEqual(result, None)

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -78,7 +78,10 @@ class TestRegistryInstrumentController(TestCase):
         self.assertEqual(result, None)
 
     @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")
-    def test_save_new_registry_instrument_for_exercise_id_and_formtype(self, mock_query):
+    @patch("application.controllers.registry_instrument.RegistryInstrumentModel")
+    def test_save_new_registry_instrument_for_exercise_id_and_formtype(
+        self, mock_registry_instrument_model, mock_query
+    ):
         session = MagicMock()
 
         # Mock a registry instrument as NOT in the database
@@ -95,12 +98,9 @@ class TestRegistryInstrumentController(TestCase):
 
         controller = RegistryInstrument()
 
-        with patch(
-            "application.controllers.registry_instrument.RegistryInstrumentModel"
-        ) as mock_registry_instrument_model:
-            result = controller.save_for_exercise_id_and_formtype.__wrapped__(
-                controller, survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
-            )
+        result = controller.save_for_exercise_id_and_formtype.__wrapped__(
+            controller, survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
+        )
 
         # Assert that a new instrument was created and saved
         mock_query.assert_called_once()

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -22,7 +22,7 @@ class TestRegistryInstrumentController(TestCase):
         controller = RegistryInstrument()
         exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
 
-        result = controller.get_registry_instruments_by_exercise_id.__wrapped__(controller, exercise_id, session)
+        result = controller.get_by_exercise_id.__wrapped__(controller, exercise_id, session)
 
         mock_query.assert_called_once()
 
@@ -38,7 +38,7 @@ class TestRegistryInstrumentController(TestCase):
         exercise_id = "invalid_uuid"
 
         with self.assertRaises(RasError) as context:
-            controller.get_registry_instruments_by_exercise_id.__wrapped__(controller, exercise_id, session)
+            controller.get_by_exercise_id.__wrapped__(controller, exercise_id, session)
 
         self.assertEqual(context.exception.errors[0], "Value is not a valid UUID (invalid_uuid)")
 
@@ -54,9 +54,7 @@ class TestRegistryInstrumentController(TestCase):
         exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
         formtype = "0001"
 
-        result = controller.get_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
-            controller, exercise_id, formtype, session
-        )
+        result = controller.get_by_exercise_id_and_formtype.__wrapped__(controller, exercise_id, formtype, session)
 
         mock_query.assert_called_once()
         mock_registry_instrument.to_dict.assert_called_once()
@@ -73,9 +71,7 @@ class TestRegistryInstrumentController(TestCase):
         exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
         formtype = "0001"
 
-        result = controller.get_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
-            controller, exercise_id, formtype, session
-        )
+        result = controller.get_by_exercise_id_and_formtype.__wrapped__(controller, exercise_id, formtype, session)
 
         mock_query.assert_called_once()
         mock_registry_instrument.to_dict.assert_not_called()
@@ -102,7 +98,7 @@ class TestRegistryInstrumentController(TestCase):
         with patch(
             "application.controllers.registry_instrument.RegistryInstrumentModel"
         ) as mock_registry_instrument_model:
-            result = controller.save_registry_instrument_for_exercise_id_and_formtype.__wrapped__(
+            result = controller.save_for_exercise_id_and_formtype.__wrapped__(
                 controller, survey_id, exercise_id, instrument_id, form_type, ci_version, published_at, guid, session
             )
 
@@ -142,7 +138,7 @@ class TestRegistryInstrumentController(TestCase):
 
         controller = RegistryInstrument()
 
-        result = controller.save_registry_instrument_for_exercise_id_and_formtype.__wrapped__(
+        result = controller.save_for_exercise_id_and_formtype.__wrapped__(
             controller, None, exercise_id, None, form_type, ci_version, published_at, guid, session
         )
 
@@ -167,9 +163,7 @@ class TestRegistryInstrumentController(TestCase):
 
         controller = RegistryInstrument()
 
-        result = controller.delete_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
-            controller, exercise_id, form_type, session
-        )
+        result = controller.delete_by_exercise_id_and_formtype.__wrapped__(controller, exercise_id, form_type, session)
 
         mock_query.assert_called_once()
         self.assertEqual(result, True)
@@ -187,9 +181,7 @@ class TestRegistryInstrumentController(TestCase):
 
         controller = RegistryInstrument()
 
-        result = controller.delete_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
-            controller, exercise_id, form_type, session
-        )
+        result = controller.delete_by_exercise_id_and_formtype.__wrapped__(controller, exercise_id, form_type, session)
 
         mock_query.assert_called_once()
         self.assertEqual(result, False)

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -27,8 +27,6 @@ class TestRegistryInstrumentController(TestCase):
         mock_query.assert_called_once()
 
         self.assertEqual(result, [{"dummy_key": "dummy_value_1"}, {"dummy_key": "dummy_value_2"}])
-        mock_registry_instrument1.to_dict.assert_called_once()
-        mock_registry_instrument2.to_dict.assert_called_once()
 
     @patch("application.controllers.registry_instrument.query_registry_instruments_by_exercise_id")
     def test_get_registry_instruments_by_exercise_id_throws_exception_when_uuid_invalid(self, mock_query):
@@ -57,7 +55,6 @@ class TestRegistryInstrumentController(TestCase):
         result = controller.get_by_exercise_id_and_formtype.__wrapped__(controller, exercise_id, formtype, session)
 
         mock_query.assert_called_once()
-        mock_registry_instrument.to_dict.assert_called_once()
         self.assertEqual(result, {"dummy_key": "dummy_value_1"})
 
     @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -153,3 +153,44 @@ class TestRegistryInstrumentController(TestCase):
         self.assertEqual(mock_registry_instrument.guid, "678a583a-87f6-4c57-9f5b-12c5ced30c1e")
         self.assertEqual(mock_registry_instrument.published_at, "2028-01-30T12:00:00")
         session.add.assert_called_once()
+
+    @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")
+    def test_delete_existing_registry_instrument_by_exercise_id_and_formtype(self, mock_query):
+        session = MagicMock()
+
+        form_type = "0002"
+        exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
+
+        # Mock the existing registry instrument to be deleted
+        mock_registry_instrument = MagicMock()
+        mock_query.return_value.first.return_value = mock_registry_instrument
+
+        controller = RegistryInstrument()
+
+        result = controller.delete_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
+            controller, exercise_id, form_type, session
+        )
+
+        mock_query.assert_called_once()
+        self.assertEqual(result, True)
+        session.delete.assert_called_once()
+
+    @patch("application.controllers.registry_instrument.query_registry_instrument_by_exercise_id_and_formtype")
+    def test_delete_non_existent_registry_instrument_by_exercise_id_and_formtype(self, mock_query):
+        session = MagicMock()
+
+        form_type = "0002"
+        exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
+
+        # Mock the non-existent registry instrument to be deleted
+        mock_query.return_value.first.return_value = None
+
+        controller = RegistryInstrument()
+
+        result = controller.delete_registry_instrument_by_exercise_id_and_formtype.__wrapped__(
+            controller, exercise_id, form_type, session
+        )
+
+        mock_query.assert_called_once()
+        self.assertEqual(result, False)
+        session.delete.assert_not_called()

--- a/tests/controllers/test_registry_instrument.py
+++ b/tests/controllers/test_registry_instrument.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from application.controllers.registry_instrument import RegistryInstrument
+
+
+class TestRegistryInstrumentController(TestCase):
+
+    @patch("application.controllers.registry_instrument.query_registry_instruments_by_exercise_id")
+    @patch("application.controllers.registry_instrument.validate_uuid")
+    def test_get_registry_instruments_by_exercise_id_returns_list_of_dicts(self, mock_validate_uuid, mock_query):
+
+        session = MagicMock()
+
+        mock_registry_instrument1 = MagicMock()
+        mock_registry_instrument1.to_dict.return_value = {"dummy_key": "dummy_value_1"}
+
+        mock_registry_instrument2 = MagicMock()
+        mock_registry_instrument2.to_dict.return_value = {"dummy_key": "dummy_value_2"}
+
+        mock_query.return_value = [mock_registry_instrument1, mock_registry_instrument2]
+
+        controller = RegistryInstrument()
+        exercise_id = "3ff59b73-7f15-406f-9e4d-7f00b41e85ce"
+
+        result = controller.get_registry_instruments_by_exercise_id.__wrapped__(controller, exercise_id, session)
+
+        mock_validate_uuid.assert_called_once_with(exercise_id)
+        mock_query.assert_called_once()
+
+        self.assertEqual(result, [{"dummy_key": "dummy_value_1"}, {"dummy_key": "dummy_value_2"}])
+        mock_registry_instrument1.to_dict.assert_called_once()
+        mock_registry_instrument2.to_dict.assert_called_once()

--- a/tests/controllers/test_registry_instrument_validator.py
+++ b/tests/controllers/test_registry_instrument_validator.py
@@ -1,0 +1,75 @@
+import datetime
+import unittest
+
+from application.controllers.registry_instrument_validator import (
+    validate_registry_instrument_payload,
+)
+from application.exceptions import RasError
+
+VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+VALID_PAYLOAD = {
+    "survey_id": VALID_UUID,
+    "exercise_id": VALID_UUID,
+    "instrument_id": VALID_UUID,
+    "classifier_type": "form_type",
+    "classifier_value": "0001",
+    "ci_version": 99,
+    "guid": VALID_UUID,
+    "published_at": datetime.datetime.now().isoformat(),
+}
+
+
+class TestValidateRegistryInstrumentPayload(unittest.TestCase):
+    def test_valid_payload(self):
+        is_valid, error = validate_registry_instrument_payload(VALID_PAYLOAD, VALID_UUID)
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+    def test_invalid_keys(self):
+        payload = VALID_PAYLOAD.copy()
+        payload.pop("guid")
+        is_valid, error = validate_registry_instrument_payload(payload, VALID_UUID)
+        self.assertFalse(is_valid)
+        self.assertIn("Invalid payload keys", error)
+
+    def test_mismatched_exercise_id(self):
+        is_valid, error = validate_registry_instrument_payload(VALID_PAYLOAD, "different-id")
+        self.assertFalse(is_valid)
+        self.assertIn("does not match path parameter", error)
+
+    def test_invalid_uuids(self):
+        for key in ["survey_id", "exercise_id", "instrument_id", "guid"]:
+            payload = VALID_PAYLOAD.copy()
+            payload[key] = "invalid_uuid"
+            try:
+                validate_registry_instrument_payload(payload, VALID_UUID)
+            except RasError as e:
+                self.assertIn("Value is not a valid UUID (invalid_uuid)", e.errors[0])
+
+    def test_invalid_classifier_type(self):
+        payload = VALID_PAYLOAD.copy()
+        payload["classifier_type"] = "bad_type"
+        is_valid, error = validate_registry_instrument_payload(payload, VALID_UUID)
+        self.assertFalse(is_valid)
+        self.assertIn("Invalid classifier type", error)
+
+    def test_invalid_classifier_value(self):
+        payload = VALID_PAYLOAD.copy()
+        payload["classifier_value"] = "abcd"
+        is_valid, error = validate_registry_instrument_payload(payload, VALID_UUID)
+        self.assertFalse(is_valid)
+        self.assertIn("Invalid classifier value", error)
+
+    def test_invalid_ci_version(self):
+        payload = VALID_PAYLOAD.copy()
+        payload["ci_version"] = "not-an-int"
+        is_valid, error = validate_registry_instrument_payload(payload, VALID_UUID)
+        self.assertFalse(is_valid)
+        self.assertIn("Invalid ci_version", error)
+
+    def test_invalid_published_at(self):
+        payload = VALID_PAYLOAD.copy()
+        payload["published_at"] = "not-a-date"
+        is_valid, error = validate_registry_instrument_payload(payload, VALID_UUID)
+        self.assertFalse(is_valid)
+        self.assertIn("Invalid published_at", error)

--- a/tests/test_data/registry_instrument.json
+++ b/tests/test_data/registry_instrument.json
@@ -1,0 +1,10 @@
+{
+  "ci_version": 3,
+  "classifier_type": "form_type",
+  "classifier_value": "0002",
+  "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
+  "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
+  "instrument_id": "77c1e406-716a-488d-bfc9-b5b988fbaccf",
+  "published_at": "2025-12-31T12:00:00",
+  "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
+}

--- a/tests/test_data/registry_instruments.json
+++ b/tests/test_data/registry_instruments.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ci_version": 1,
+    "classifier_type": "form_type",
+    "classifier_value": "0001",
+    "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
+    "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
+    "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
+    "published_at": "2025-12-31T00:00:00",
+    "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
+  },
+  {
+    "ci_version": 3,
+    "classifier_type": "form_type",
+    "classifier_value": "0002",
+    "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
+    "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
+    "instrument_id": "77c1e406-716a-488d-bfc9-b5b988fbaccf",
+    "published_at": "2025-12-31T12:00:00",
+    "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
+  }
+]

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -23,13 +23,15 @@ class TestRegistryInstrumentView(TestClient):
             "application.views.registry_instrument_view." "RegistryInstrument.get_by_exercise_id_and_formtype"
         ) as mock_get_registry_instrument_by_exercise_id_and_formtype:
             with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
-                mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = json.load(f)
+                registry_instrument_json = json.load(f)
+                mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = registry_instrument_json
             response = self.client.get(
                 f"{api_root}/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type_exists}",
                 headers=self.get_auth_headers(),
             )
             self.assertStatus(response, 200)
             self.assertEqual(len(response.json), 8)  # The 8 fields of a registry instrument
+            self.assertEqual(response.json, registry_instrument_json)
             self.assertEqual(response.headers["Content-Type"], "application/json")
             mock_get_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
                 exercise_id, form_type_exists
@@ -45,7 +47,7 @@ class TestRegistryInstrumentView(TestClient):
                 headers=self.get_auth_headers(),
             )
             self.assertStatus(response, 404)
-            self.assertEqual(response.data.decode(), "Not Found")  # The 8 fields of a registry instrument
+            self.assertEqual(response.data.decode(), "Not Found")
             self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
             mock_get_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
                 exercise_id, form_type_does_not_exist

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -114,7 +114,7 @@ class TestRegistryInstrumentView(TestClient):
                 exercise_id, form_type_does_not_exist
             )
 
-    def test_put_new_registry_instrument_returns_201(self):
+    def test_successful_put_new_registry_instrument_returns_201(self):
         with patch(
             "application.views.registry_instrument_view."
             "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
@@ -132,7 +132,7 @@ class TestRegistryInstrumentView(TestClient):
             self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
             mock_save_registry_instrument_for_exercise_id_and_formtype.assert_called_once()
 
-    def test_put_existing_registry_instrument_returns_200(self):
+    def test_successful_put_existing_registry_instrument_returns_200(self):
         with patch(
             "application.views.registry_instrument_view."
             "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
@@ -150,7 +150,7 @@ class TestRegistryInstrumentView(TestClient):
             self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
             mock_save_registry_instrument_for_exercise_id_and_formtype.assert_called_once()
 
-    def test_put_existing_registry_instrument_returns_500(self):
+    def test_unsuccessful_put_registry_instrument_returns_500(self):
         with patch(
             "application.views.registry_instrument_view."
             "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
@@ -167,6 +167,36 @@ class TestRegistryInstrumentView(TestClient):
             self.assertEqual(response.data.decode(), "Registry instrument failed to save successfully")
             self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
             mock_save_registry_instrument_for_exercise_id_and_formtype.assert_called_once()
+
+    def test_put_registry_instrument_wrong_payload_returns_400(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+        ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
+            mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (False, None)
+            response = self.client.put(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}",
+                data=json.dumps({"invalid_key": "invalid_value"}),
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 400)
+            self.assertIn("Invalid payload keys. Expected", response.data.decode())
+            self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
+
+    def test_put_registry_instrument_invalid_json_payload_returns_400(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+        ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
+            mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (False, None)
+            response = self.client.put(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}",
+                data="not_valid_json",
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 400)
+            self.assertIn("Invalid JSON payload", response.data.decode())
+            self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
 
     @staticmethod
     def get_auth_headers():

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -20,8 +20,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_get_registry_instrument_returns_200_and_object(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.get_registry_instrument_by_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.get_by_exercise_id_and_formtype"
         ) as mock_get_registry_instrument_by_exercise_id_and_formtype:
             with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
                 mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = json.load(f)
@@ -38,8 +37,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_get_registry_instrument_returns_404(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.get_registry_instrument_by_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.get_by_exercise_id_and_formtype"
         ) as mock_get_registry_instrument_by_exercise_id_and_formtype:
             mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = None
             response = self.client.get(
@@ -55,7 +53,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_get_registry_instruments_returns_200_and_empty_list(self):
         with patch(
-            "application.views.registry_instrument_view.RegistryInstrument.get_registry_instruments_by_exercise_id"
+            "application.views.registry_instrument_view.RegistryInstrument.get_by_exercise_id"
         ) as mock_get_registry_instruments_by_exercise_id:
             mock_get_registry_instruments_by_exercise_id.return_value = []
             response = self.client.get(
@@ -69,7 +67,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_get_registry_instruments_returns_200_and_list_of_objects(self):
         with patch(
-            "application.views.registry_instrument_view.RegistryInstrument.get_registry_instruments_by_exercise_id"
+            "application.views.registry_instrument_view.RegistryInstrument.get_by_exercise_id"
         ) as mock_get_registry_instruments_by_exercise_id:
             with open(Path(__file__).parent.parent / "test_data" / "registry_instruments.json") as f:
                 mock_get_registry_instruments_by_exercise_id.return_value = json.load(f)
@@ -84,8 +82,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_successful_delete_registry_instrument_returns_200(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.delete_registry_instrument_by_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.delete_by_exercise_id_and_formtype"
         ) as mock_delete_registry_instrument_by_exercise_id_and_formtype:
             mock_delete_registry_instrument_by_exercise_id_and_formtype.return_value = True
             response = self.client.delete(
@@ -100,8 +97,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_unsuccessful_delete_registry_instrument_returns_404(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.delete_registry_instrument_by_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.delete_by_exercise_id_and_formtype"
         ) as mock_delete_registry_instrument_by_exercise_id_and_formtype:
             mock_delete_registry_instrument_by_exercise_id_and_formtype.return_value = False
             response = self.client.delete(
@@ -116,8 +112,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_successful_put_new_registry_instrument_returns_201(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.save_for_exercise_id_and_formtype"
         ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
             mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (True, True)
             with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
@@ -134,8 +129,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_successful_put_existing_registry_instrument_returns_200(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.save_for_exercise_id_and_formtype"
         ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
             mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (True, False)
             with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
@@ -152,8 +146,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_unsuccessful_put_registry_instrument_returns_500(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.save_for_exercise_id_and_formtype"
         ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
             mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (False, None)
             with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
@@ -170,8 +163,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_put_registry_instrument_wrong_payload_returns_400(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.save_for_exercise_id_and_formtype"
         ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
             mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (False, None)
             response = self.client.put(
@@ -185,8 +177,7 @@ class TestRegistryInstrumentView(TestClient):
 
     def test_put_registry_instrument_invalid_json_payload_returns_400(self):
         with patch(
-            "application.views.registry_instrument_view."
-            "RegistryInstrument.save_registry_instrument_for_exercise_id_and_formtype"
+            "application.views.registry_instrument_view." "RegistryInstrument.save_for_exercise_id_and_formtype"
         ) as mock_save_registry_instrument_for_exercise_id_and_formtype:
             mock_save_registry_instrument_for_exercise_id_and_formtype.return_value = (False, None)
             response = self.client.put(

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -95,7 +95,7 @@ class TestRegistryInstrumentView(TestClient):
                 exercise_id, form_type_exists
             )
 
-    def test_unsuccessful_delete_registry_instrument_returns_404(self):
+    def test_unsuccessful_delete_registry_instrument_missing_instrument(self):
         with patch(
             "application.views.registry_instrument_view." "RegistryInstrument.delete_by_exercise_id_and_formtype"
         ) as mock_delete_registry_instrument_by_exercise_id_and_formtype:

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -1,0 +1,53 @@
+import base64
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from flask import current_app
+
+from tests.test_client import TestClient
+
+api_root = "/collection-instrument-api/1.0.2"
+exercise_id = "c3c0403a-6e9c-46f6-af5e-5f67fefb2a9d"
+
+
+class TestRegistryInstrumentView(TestClient):
+    """
+    Registry Instrument view unit tests
+    """
+
+    def test_get_registry_instruments_returns_200_and_empty_list(self):
+        with patch(
+            "application.views.registry_instrument_view.RegistryInstrument.get_registry_instruments_by_exercise_id"
+        ) as mock_get_registry_instruments_by_exercise_id:
+            mock_get_registry_instruments_by_exercise_id.return_value = []
+            response = self.client.get(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 200)
+            self.assertEqual(response.json, [])
+            self.assertEqual(response.headers["Content-Type"], "application/json")
+            mock_get_registry_instruments_by_exercise_id.assert_called_once_with(exercise_id)
+
+    def test_get_registry_instruments_returns_200_and_list_of_objects(self):
+        with patch(
+            "application.views.registry_instrument_view.RegistryInstrument.get_registry_instruments_by_exercise_id"
+        ) as mock_get_registry_instruments_by_exercise_id:
+            with open(Path(__file__).parent.parent / "test_data" / "registry_instruments.json") as f:
+                mock_get_registry_instruments_by_exercise_id.return_value = json.load(f)
+            response = self.client.get(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 200)
+            self.assertEqual(len(response.json), 2)
+            self.assertEqual(response.headers["Content-Type"], "application/json")
+            mock_get_registry_instruments_by_exercise_id.assert_called_once_with(exercise_id)
+
+    @staticmethod
+    def get_auth_headers():
+        auth = "{}:{}".format(
+            current_app.config.get("SECURITY_USER_NAME"), current_app.config.get("SECURITY_USER_PASSWORD")
+        ).encode("utf-8")
+        return {"Authorization": "Basic %s" % base64.b64encode(bytes(auth)).decode("ascii")}

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -9,12 +9,49 @@ from tests.test_client import TestClient
 
 api_root = "/collection-instrument-api/1.0.2"
 exercise_id = "c3c0403a-6e9c-46f6-af5e-5f67fefb2a9d"
+form_type_exists = "0001"
+form_type_does_not_exist = "9999"
 
 
 class TestRegistryInstrumentView(TestClient):
     """
     Registry Instrument view unit tests
     """
+
+    def test_get_registry_instrument_returns_200_and_object(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.get_registry_instrument_by_exercise_id_and_formtype"
+        ) as mock_get_registry_instrument_by_exercise_id_and_formtype:
+            with open(Path(__file__).parent.parent / "test_data" / "registry_instrument.json") as f:
+                mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = json.load(f)
+            response = self.client.get(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type_exists}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 200)
+            self.assertEqual(len(response.json), 8)  # The 8 fields of a registry instrument
+            self.assertEqual(response.headers["Content-Type"], "application/json")
+            mock_get_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
+                exercise_id, form_type_exists
+            )
+
+    def test_get_registry_instrument_returns_404(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.get_registry_instrument_by_exercise_id_and_formtype"
+        ) as mock_get_registry_instrument_by_exercise_id_and_formtype:
+            mock_get_registry_instrument_by_exercise_id_and_formtype.return_value = None
+            response = self.client.get(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type_does_not_exist}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertStatus(response, 404)
+            self.assertEqual(response.data.decode(), "Not Found")  # The 8 fields of a registry instrument
+            self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
+            mock_get_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
+                exercise_id, form_type_does_not_exist
+            )
 
     def test_get_registry_instruments_returns_200_and_empty_list(self):
         with patch(
@@ -41,7 +78,7 @@ class TestRegistryInstrumentView(TestClient):
                 headers=self.get_auth_headers(),
             )
             self.assertStatus(response, 200)
-            self.assertEqual(len(response.json), 2)
+            self.assertEqual(len(response.json), 2)  # The 2 registry instrument objects in the test data
             self.assertEqual(response.headers["Content-Type"], "application/json")
             mock_get_registry_instruments_by_exercise_id.assert_called_once_with(exercise_id)
 

--- a/tests/views/test_registry_instrument_view.py
+++ b/tests/views/test_registry_instrument_view.py
@@ -82,6 +82,38 @@ class TestRegistryInstrumentView(TestClient):
             self.assertEqual(response.headers["Content-Type"], "application/json")
             mock_get_registry_instruments_by_exercise_id.assert_called_once_with(exercise_id)
 
+    def test_successful_delete_registry_instrument_returns_200(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.delete_registry_instrument_by_exercise_id_and_formtype"
+        ) as mock_delete_registry_instrument_by_exercise_id_and_formtype:
+            mock_delete_registry_instrument_by_exercise_id_and_formtype.return_value = True
+            response = self.client.delete(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type_exists}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertEqual(response.data.decode(), "Successfully deleted registry instrument")
+            self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
+            mock_delete_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
+                exercise_id, form_type_exists
+            )
+
+    def test_unsuccessful_delete_registry_instrument_returns_404(self):
+        with patch(
+            "application.views.registry_instrument_view."
+            "RegistryInstrument.delete_registry_instrument_by_exercise_id_and_formtype"
+        ) as mock_delete_registry_instrument_by_exercise_id_and_formtype:
+            mock_delete_registry_instrument_by_exercise_id_and_formtype.return_value = False
+            response = self.client.delete(
+                f"{api_root}/registry-instrument/exercise-id/{exercise_id}/formtype/{form_type_does_not_exist}",
+                headers=self.get_auth_headers(),
+            )
+            self.assertEqual(response.data.decode(), "Not Found")
+            self.assertEqual(response.headers["Content-Type"], "text/html; charset=utf-8")
+            mock_delete_registry_instrument_by_exercise_id_and_formtype.assert_called_once_with(
+                exercise_id, form_type_does_not_exist
+            )
+
     @staticmethod
     def get_auth_headers():
         auth = "{}:{}".format(


### PR DESCRIPTION
# What and why?

Introduction of the new registry instrument resource.

>_Due to the complications detailed under [OPTION 1](https://github.com/ONSdigital/ras-rm-documentation/tree/main/spike/cir-integration#option-1) in the original design proposal, this solution does NOT address the already complex and redundant RASRM survey scoped collection instrument relationships. Indeed, this solution to introduce CIR deliberately sidesteps that data model, and introduces selected CIR resources, named `registry-instrument`, and keyed on RASRM UUID references, and explicitly operated on (CRUD) by its own API._

>_The consequence of this is loose data integrity, where the foreign and primary keys of the integer ID sequences for surveys, exercises and instruments are not used (as these are provided solely by survey scoped association tables). The new CIR instruments will be referenced by the UUID of a collection exercise and its explicit `formtype` classifier._

>_The CRUD operations required on these new resources will be done from within the context of the collection-exercise object in Rops. As such, the keys by which these CIR objects will be referenced will be within that scope and available from within the CIR pages._

>_Extending the existing API to include the selected CIR objects when returning the RM collection instruments is out of scope for this card (although that could be introduced at a later date)._

>_This means that additional/explicit HTTP requests will be required to request the selected CIR objects, and to interpolate the registry instruments with our collection instruments when building the pages. However, this will be straight forward, and requests will be non-complex, infrequent and fairly light._

>_This is intended to be an interim design, and would be completely replaced if/when the more appropriate [OPTION 2](https://github.com/ONSdigital/ras-rm-documentation/tree/main/spike/cir-integration#option-2) is delivered. There is no point in re-engineering the current poor data model to accommodate CIR._

- `RegistryInstrument` model and db tables
- Alembic migration for existing environments
- Flask view for `registry_instrument`
- Controller for `registry_instrument`
- API design for `RegistryInstrument` objects
- API implementation to `PUT` (create or update) registry instrument for a collection exercise ID
- API implementation to `GET` registry instruments by collection exercise ID
- API implementation to `GET` a registry instrument by collection exercise ID and form type
- API implementation to `DELETE` a registry instrument by collection exercise ID and form type

When working with the new APIs in the context of CIR features, the pages that will be making requests will have all the necessary request data in scope.

For example, the `/response_operations_ui/views/collection_exercise.py` has the user selected instrument data (including `form_type` and `instrument_id` values) in scope in the `linked_eq_ci` object, and the `collection_exercise_id` is in scope as `ce_details["collection_exercise"]["id"]`.

# How to test?

- build and run the tests locally
- deploy to your namespace
- use the API or run the SQL query below to insert or update selected CIR versions into the `registry_instrument` table
- use the API or run the SQL query below to retrieve selected CIR versions from the `registry_instrument` table

# API requests

> _Save a selected registry instrument for the given exercise UUID._

[OpenAPI spec](https://github.com/ONSdigital/ras-collection-instrument/blob/introduce-cir-instrument-resource/openapi.yaml#L432-L466)

```
curl --request PUT --location 'http://localhost:8002/collection-instrument-api/1.0.2/registry-instrument/exercise-id/59bc62d0-06a7-41ac-bd4a-6a7026ad94cd' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic YWRtaW46c2VjcmV0' \
--data '{
    "ci_version": 1,
    "classifier_type": "form_type",
    "classifier_value": "0007",
    "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
    "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
    "instrument_id": "efc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
    "published_at": "2025-12-31T00:00:00",
    "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
}'
```

...should yield an HTTP `201` or `200` that the selected registry instrument version was created or updated for the collection exercise...

```
201 Successfully saved registry instrument
200 Successfully saved registry instrument
```

> _Get a list of selected registry instruments for the given exercise UUID._

[OpenAPI spec](https://github.com/ONSdigital/ras-collection-instrument/blob/introduce-cir-instrument-resource/openapi.yaml#L467-L490)

```
curl --location 'http://localhost:8002/collection-instrument-api/1.0.2/registry-instrument/exercise-id/3ff59b73-7f15-406f-9e4d-7f00b41e85ce' \
--header 'Authorization: Basic YWRtaW46c2VjcmV0'
```

...should yield a list of registry instrument versions selected for form types for the collection exercise...

```
[
        {
            "ci_version": 1,
            "classifier_type": "form_type",
            "classifier_value": "0001",
            "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
            "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
            "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
            "published_at": "2025-12-31T00:00:00",
            "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
        },
        {
            "ci_version": 3,
            "classifier_type": "form_type",
            "classifier_value": "0002",
            "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
            "guid": "ac3c5a3a-2ebb-47dc-9727-22c473086a82",
            "instrument_id": "77c1e406-716a-488d-bfc9-b5b988fbaccf",
            "published_at": "2025-12-31T12:00:00",
            "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
        }
]
```

> _Get a selected registry instrument for the given exercise UUID and form type classifier value._

[OpenAPI spec](https://github.com/ONSdigital/ras-collection-instrument/blob/introduce-cir-instrument-resource/openapi.yaml#L492-L523)

```
curl --location 'http://localhost:8002/collection-instrument-api/1.0.2/registry-instrument/exercise-id/3ff59b73-7f15-406f-9e4d-7f00b41e85ce/formtype/0001' \
--header 'Authorization: Basic YWRtaW46c2VjcmV0'
```

...should yield the registry instrument version selected for the form type for the collection exercise...

```
{
    "ci_version": 1,
    "classifier_type": "form_type",
    "classifier_value": "0001",
    "exercise_id": "3ff59b73-7f15-406f-9e4d-7f00b41e85ce",
    "guid": "c046861a-0df7-443a-a963-d9aa3bddf328",
    "instrument_id": "dfc3ddd7-3e79-4c6b-a8f8-1fa184cdd06b",
    "published_at": "2025-12-31T00:00:00",
    "survey_id": "0b1f8376-28e9-4884-bea5-acf9d709464e"
}
```

> _Delete a selected registry instrument for the given exercise UUI and form type classifier value._

[Open API spec](https://github.com/ONSdigital/ras-collection-instrument/blob/introduce-cir-instrument-resource/openapi.yaml#L524-L554)

```
curl --request DELETE --location 'http://localhost:8002/collection-instrument-api/1.0.2/registry-instrument/exercise-id/27af467d-4dfe-4d23-b43c-2b8f1b52f25e/formtype/0004' \
--header 'Authorization: Basic YWRtaW46c2VjcmV0'
```
...should yield...
```
200 Successfully deleted registry instrument
```

# SQL Statements

You can also shove data into the DB with the following statements (`survey_id` and `collection_exercise_id` are the first two values respectively). You might want these to align with your own test data depending on what you're doing)

```
INSERT into ras_ci.registry_instrument
VALUES('0b1f8376-28e9-4884-bea5-acf9d709464e',
	  '3ff59b73-7f15-406f-9e4d-7f00b41e85ce',
	  '4952b0f2-838f-4902-a441-b41a4cd9d3bc',
	  'form_type',
	  '0001',
	  1,
	  'c046861a-0df7-443a-a963-d9aa3bddf328',
          '2025-12-31T00:00:00');

INSERT into ras_ci.registry_instrument
VALUES('0b1f8376-28e9-4884-bea5-acf9d709464e',
	  '3ff59b73-7f15-406f-9e4d-7f00b41e85ce',
	  '77c1e406-716a-488d-bfc9-b5b988fbaccf',
	  'form_type',
	  '0002',
	  1,
	  'ac3c5a3a-2ebb-47dc-9727-22c473086a82',
          '2025-12-31T00:00:00');
```

For reference, once selected registry instruments exist, their relationship with the survey scoped collection instruments can be seen with this reference query

```
SELECT
  a.survey_id,
  b.exercise_id,
  c.instrument_id,
  c.type,
  c.classifiers,
  e.classifier_value,
  e.ci_version,
  e.guid
 
FROM ras_ci.survey a
    FULL OUTER JOIN ras_ci.instrument c
	  ON a.id = c.survey_id
    FULL OUTER JOIN ras_ci.instrument_exercise d
	  ON  c.id = d.instrument_id
    FULL OUTER JOIN ras_ci.exercise b
	  ON b.id = d.exercise_id
    FULL OUTER JOIN ras_ci.registry_instrument e
	  ON b.exercise_id = e.exercise_id

WHERE
  a.survey_id = '0b1f8376-28e9-4884-bea5-acf9d709464e'
  AND b.exercise_id = '59bc62d0-06a7-41ac-bd4a-6a7026ad94cd'
  AND e.classifier_type = 'form_type'
  AND e.classifier_value = c.classifiers->>'form_type';
```

# Jira

https://jira.ons.gov.uk/browse/RAS-1603