### PR TITLE
Interim alembic fix for broken dev envs

### DIFF
--- a/migrations/versions/9a724381cde7_add_registry_instrument_count_view.py
+++ b/migrations/versions/9a724381cde7_add_registry_instrument_count_view.py
@@ -20,6 +20,9 @@ def upgrade():
         """CREATE VIEW ras_ci.registry_instrument_count as SELECT exercise_id, count(*) as count
         FROM ras_ci.registry_instrument GROUP BY exercise_id; """
     )
+    op.create_index(
+        "ix_registry_instrument_exercise_id", "registry_instrument", ["exercise_id"], unique=False, schema="ras_ci"
+    )
 
 
 def downgrade():

--- a/run.py
+++ b/run.py
@@ -91,7 +91,11 @@ def create_database(db_connection, db_schema):
             models.Base.metadata.create_all(engine)
             # If the db is created from scratch we don't need to update with alembic,
             # however we do need to record (stamp) the latest version for future migrations
-            command.stamp(alembic_cfg, "head")
+            # THE ABOVE HISTORICAL STATEMENT IS NOT TRUE AND IS NOW CAUSING AN ISSUE. IT DID NOT CONSIDER
+            # NON-TABLE MIGRATIONS SUCH AS VIEWS OR INDEXES (THESE ARE NOT DEFINED IN SQLALCHEMY)
+            # IT DOES NOT IMPACT PREPROD/PROD BUT THIS INTERIM HACK IS TO ALLOW EXISTING DEV ENVS TO WORK
+            command.stamp(alembic_cfg, "b730b3a81f72")
+            apply_explicit_migrations(alembic_cfg)
         else:
             logger.info("Updating database with Alembic")
             command.upgrade(alembic_cfg, "head")
@@ -102,6 +106,21 @@ def create_database(db_connection, db_schema):
 
     logger.info("Ok, database tables have been created")
     return engine
+
+
+def apply_explicit_migrations(alembic_cfg):
+    """
+    Interim fix to allow non-table migrations to be applied
+    """
+    revisions = [
+        "9a724381cde7",
+    ]
+    for revision in revisions:
+        try:
+            logger.info(f"Applying Alembic migration {revision}")
+            command.upgrade(alembic_cfg, revision)
+        except Exception as e:
+            logger.error(f"Failed to apply Alembic migration {revision}: {e}")
 
 
 def retry_if_database_error(exception):


### PR DESCRIPTION
# What and why?

The existing strategy when creating a new `ras_ci` schema did not consider those objects types NOT defined in SQLAlchemy models. It only considered table objects defined in SQLAlchemy models.

As such, the recent `view` and `index` objects introduced in Alembic migrations for the registry instruments are NOT created when creating a new schema (essentially dev/performance environments). These objects cannot be created by SQLAlchemy definitions in the same way tables are. They can only be created explicitly by code frameworks (i.e. Alembic).

The issue does NOT affect prod or preprod as the schemas are long standing and already exist. As such, the Alembic migrations for those envs are correctly applied. Preprod correctly has the views and index for registry instruments in its schema, along with the correct migration revision `9a724381cde7`.

However, we need to consider the strategies for prod/preprod AND dev environment. These have conflicting requirements.

This PR introduces an inelegant workaround to the problem in dev while I work out a suitable approach. Instead of setting the Alembic revision to the most recent `9a724381cde7` in the assumption that SQLAlchemy has created all the objects, it sets the revision to the previous `b730b3a81f72` and then calls the Alembic script which applies most recent `9a724381cde7` revision containing the registry instrument view (and index).

This is far from ideal, and will need further thinking about when future migrations are added. We might need to update existing migration scripts (which itself not ideal) to check for objects before trying to create them, and then run all the migrations in regardless.

# How to test?

- deploy to a NEW dev env and check the `ras_ci` schema, and all the tables and view and index are created.
- deploy to an EXISTING previous version env, and check the view and index are created.

# Jira

n/a
