### PR TITLE
RAS-2033: Migrate collection-instrument to WIF

### DIFF
--- a/_infra/helm/collection-instrument/Chart.yaml
+++ b/_infra/helm/collection-instrument/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.66
+version: 3.0.67
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.66
+appVersion: 3.0.67

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -19,19 +19,9 @@ spec:
         app: {{ .Chart.Name }}
         env: {{ .Values.env }}
     spec:
-      volumes:
-      - name: google-cloud-key
-        secret:
-          secretName: google-application-credentials
-      {{- if .Values.database.sqlProxyEnabled }}
-      - name: cloudsql-instance-credentials
-        secret:
-          secretName: cloudsql-proxy-credentials
-          defaultMode: 0444
-          items:
-          - key: "credentials.json"
-            path: "credentials.json"
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      imagePullSecrets:
+          {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:
         {{- if .Values.database.sqlProxyEnabled }}
         - name: cloudsql-proxy
@@ -39,16 +29,11 @@ spec:
           command: ["/cloud_sql_proxy",
                     "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
                     "-ip_address_types=PRIVATE",
-                    "-credential_file=/secrets/cloudsql/credentials.json",
                     "-term_timeout=30s",
                     "-verbose=false"]
           securityContext:
             runAsUser: 2  # non-root user
             allowPrivilegeEscalation: false
-          volumeMounts:
-            - name: cloudsql-instance-credentials
-              mountPath: /secrets/cloudsql
-              readOnly: true
           env:
           - name: SQL_INSTANCE_NAME
             valueFrom:
@@ -144,8 +129,6 @@ spec:
             value: "{{ .Values.container.port }}"
           - name: CONFIG_YML
             value: "config/config-docker.yaml"
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /var/secrets/google/credentials.json
           - name: ONS_CRYPTOKEY
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       imagePullSecrets:
           {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         {{- if .Values.database.sqlProxyEnabled }}
         - name: cloudsql-proxy

--- a/_infra/helm/collection-instrument/templates/deployment.yaml
+++ b/_infra/helm/collection-instrument/templates/deployment.yaml
@@ -55,9 +55,6 @@ spec:
           image: "{{ .Values.image.devRepo }}/{{ .Chart.Name }}:{{ .Values.image.tag }}"
           {{- end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          volumeMounts:
-            - name: google-cloud-key
-              mountPath: /var/secrets/google
           ports:
             - name: http-server
               containerPort: {{ .Values.container.port }}

--- a/_infra/helm/collection-instrument/values.yaml
+++ b/_infra/helm/collection-instrument/values.yaml
@@ -1,6 +1,12 @@
 namespace: minikube
 env: minikube
 
+serviceAccount:
+  name: ras-rm-k8s-services
+
+imagePullSecrets:
+  - name: gar-secret
+
 image:
   devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images


### PR DESCRIPTION
# What and why?
Migrates collection-instrument to WIF and removes cloud sql proxy credentials. 
# How to test?
Deploy using helm, spinnaker pipeline or locally and test collection instrument functionality is unchanged. 

Cloud sql proxy changes will need testing in performance or staging. 
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-2033